### PR TITLE
Add support for local modifications in ~/.gdbinit.local

### DIFF
--- a/gdbinit
+++ b/gdbinit
@@ -79,9 +79,7 @@ set $X86FLAVOR = 0
 set confirm off
 set verbose off
 
-if $COLOUREDPROMPT == 1
-	set prompt \033[31mgdb$ \033[0m
-end
+
 
 set output-radix 0x10
 set input-radix 0x10
@@ -97,7 +95,13 @@ set $CONTEXTSIZE_STACK = 6
 set $CONTEXTSIZE_DATA  = 8
 set $CONTEXTSIZE_CODE  = 8
 
+source ~/.gdbinit.local
+
 # __________________end gdb options_________________
+#
+if $COLOUREDPROMPT == 1
+	set prompt \033[31mgdb$ \033[0m
+end
 
 # Initialize these variables else comparisons will fail for colouring
 # we must initialize all of them at once, 32 and 64 bits, and ARM.


### PR DESCRIPTION
After setting the default options, ~/.gdbinit.local is read, enabling
the user to override the default settings or adding own config parts
without editing the main gdbinit. This should make updates easier.

To allow disabling prompt coloring in that way, the prompt-setting code
was moved as well.

No error or warning is raised if the file does not exist (gdb 7.4.1-debian).
