### PR TITLE
fix $eflags invalid cast

### DIFF
--- a/gdbinit
+++ b/gdbinit
@@ -553,7 +553,7 @@ end
 
 define flagsx86
     # OF (overflow) flag
-    if (($eflags >> 0xB) & 1)
+    if (((unsigned int)$eflags >> 0xB) & 1)
         printf "O "
         set $_of_flag = 1
     else
@@ -561,25 +561,25 @@ define flagsx86
         set $_of_flag = 0
     end
     # DF (direction) flag
-    if (($eflags >> 0xA) & 1)
+    if (((unsigned int)$eflags >> 0xA) & 1)
         printf "D "
     else
         printf "d "
     end
     # IF (interrupt enable) flag
-    if (($eflags >> 9) & 1)
+    if (((unsigned int)$eflags >> 9) & 1)
         printf "I "
     else
         printf "i "
     end
     # TF (trap) flag
-    if (($eflags >> 8) & 1)
+    if (((unsigned int)$eflags >> 8) & 1)
         printf "T "
     else
         printf "t "
     end
     # SF (sign) flag
-    if (($eflags >> 7) & 1)
+    if (((unsigned int)$eflags >> 7) & 1)
         printf "S "
         set $_sf_flag = 1
     else
@@ -587,7 +587,7 @@ define flagsx86
         set $_sf_flag = 0
     end
     # ZF (zero) flag
-    if (($eflags >> 6) & 1)
+    if (((unsigned int)$eflags >> 6) & 1)
         printf "Z "
     	set $_zf_flag = 1
     else
@@ -595,13 +595,13 @@ define flagsx86
 	    set $_zf_flag = 0
     end
     # AF (adjust) flag
-    if (($eflags >> 4) & 1)
+    if (((unsigned int)$eflags >> 4) & 1)
         printf "A "
     else
         printf "a "
     end
     # PF (parity) flag
-    if (($eflags >> 2) & 1)
+    if (((unsigned int)$eflags >> 2) & 1)
         printf "P "
 	    set $_pf_flag = 1
     else
@@ -609,7 +609,7 @@ define flagsx86
     	set $_pf_flag = 0
     end
     # CF (carry) flag
-    if ($eflags & 1)
+    if ((unsigned int)$eflags & 1)
         printf "C "
 	    set $_cf_flag = 1
     else
@@ -649,17 +649,17 @@ define eflags
                ($cpsr->t & 1)
      else
         printf "     OF <%d>  DF <%d>  IF <%d>  TF <%d>",\
-               (($eflags >> 0xB) & 1), (($eflags >> 0xA) & 1), \
-               (($eflags >> 9) & 1), (($eflags >> 8) & 1)
+               (((unsigned int)$eflags >> 0xB) & 1), (((unsigned int)$eflags >> 0xA) & 1), \
+               (((unsigned int)$eflags >> 9) & 1), (((unsigned int)$eflags >> 8) & 1)
         printf "  SF <%d>  ZF <%d>  AF <%d>  PF <%d>  CF <%d>\n",\
-               (($eflags >> 7) & 1), (($eflags >> 6) & 1),\
-               (($eflags >> 4) & 1), (($eflags >> 2) & 1), ($eflags & 1)
+               (((unsigned int)$eflags >> 7) & 1), (((unsigned int)$eflags >> 6) & 1),\
+               (((unsigned int)$eflags >> 4) & 1), (((unsigned int)$eflags >> 2) & 1), ((unsigned int)$eflags & 1)
         printf "     ID <%d>  VIP <%d> VIF <%d> AC <%d>",\
-               (($eflags >> 0x15) & 1), (($eflags >> 0x14) & 1), \
-               (($eflags >> 0x13) & 1), (($eflags >> 0x12) & 1)
+               (((unsigned int)$eflags >> 0x15) & 1), (((unsigned int)$eflags >> 0x14) & 1), \
+               (((unsigned int)$eflags >> 0x13) & 1), (((unsigned int)$eflags >> 0x12) & 1)
         printf "  VM <%d>  RF <%d>  NT <%d>  IOPL <%d>\n",\
-               (($eflags >> 0x11) & 1), (($eflags >> 0x10) & 1),\
-               (($eflags >> 0xE) & 1), (($eflags >> 0xC) & 3)
+               (((unsigned int)$eflags >> 0x11) & 1), (((unsigned int)$eflags >> 0x10) & 1),\
+               (((unsigned int)$eflags >> 0xE) & 1), (((unsigned int)$eflags >> 0xC) & 3)
      end
 end
 document eflags
@@ -2452,10 +2452,10 @@ define cfc
             set $cpsr->c = $tempflag|0x1
         end
      else
-        if ($eflags & 1)
-            set $eflags = $eflags&~0x1
+        if ((unsigned int)$eflags & 1)
+            set (unsigned int)$eflags = (unsigned int)$eflags&~0x1
         else
-            set $eflags = $eflags|0x1
+            set (unsigned int)$eflags = (unsigned int)$eflags|0x1
         end
      end
 end
@@ -2465,10 +2465,10 @@ end
 
 
 define cfp
-    if (($eflags >> 2) & 1)
-        set $eflags = $eflags&~0x4
+    if (((unsigned int)$eflags >> 2) & 1)
+        set (unsigned int)$eflags = (unsigned int)$eflags&~0x4
     else
-        set $eflags = $eflags|0x4
+        set (unsigned int)$eflags = (unsigned int)$eflags|0x4
     end
 end
 document cfp
@@ -2477,10 +2477,10 @@ end
 
 
 define cfa
-    if (($eflags >> 4) & 1)
-        set $eflags = $eflags&~0x10
+    if (((unsigned int)$eflags >> 4) & 1)
+        set (unsigned int)$eflags = (unsigned int)$eflags&~0x10
     else
-        set $eflags = $eflags|0x10
+        set (unsigned int)$eflags = (unsigned int)$eflags|0x10
     end
 end
 document cfa
@@ -2498,10 +2498,10 @@ define cfz
             set $cpsr->z = $tempflag|0x1
         end
      else
-        if (($eflags >> 6) & 1)
-            set $eflags = $eflags&~0x40
+        if (((unsigned int)$eflags >> 6) & 1)
+            set (unsigned int)$eflags = (unsigned int)$eflags&~0x40
         else
-            set $eflags = $eflags|0x40
+            set (unsigned int)$eflags = (unsigned int)$eflags|0x40
         end
      end
 end
@@ -2511,10 +2511,10 @@ end
 
 
 define cfs
-    if (($eflags >> 7) & 1)
-        set $eflags = $eflags&~0x80
+    if (((unsigned int)$eflags >> 7) & 1)
+        set (unsigned int)$eflags = (unsigned int)$eflags&~0x80
     else
-        set $eflags = $eflags|0x80
+        set (unsigned int)$eflags = (unsigned int)$eflags|0x80
     end
 end
 document cfs
@@ -2523,10 +2523,10 @@ end
 
 
 define cft
-    if (($eflags >>8) & 1)
-        set $eflags = $eflags&~0x100
+    if (((unsigned int)$eflags >>8) & 1)
+        set (unsigned int)$eflags = (unsigned int)$eflags&~0x100
     else
-        set $eflags = $eflags|0x100
+        set (unsigned int)$eflags = (unsigned int)$eflags|0x100
     end
 end
 document cft
@@ -2535,10 +2535,10 @@ end
 
 
 define cfi
-    if (($eflags >> 9) & 1)
-        set $eflags = $eflags&~0x200
+    if (((unsigned int)$eflags >> 9) & 1)
+        set (unsigned int)$eflags = (unsigned int)$eflags&~0x200
     else
-        set $eflags = $eflags|0x200
+        set (unsigned int)$eflags = (unsigned int)$eflags|0x200
     end
 end
 document cfi
@@ -2549,10 +2549,10 @@ end
 
 
 define cfd
-    if (($eflags >>0xA) & 1)
-        set $eflags = $eflags&~0x400
+    if (((unsigned int)$eflags >>0xA) & 1)
+        set (unsigned int)$eflags = (unsigned int)$eflags&~0x400
     else
-        set $eflags = $eflags|0x400
+        set (unsigned int)$eflags = (unsigned int)$eflags|0x400
     end
 end
 document cfd
@@ -2561,10 +2561,10 @@ end
 
 
 define cfo
-    if (($eflags >> 0xB) & 1)
-        set $eflags = $eflags&~0x800
+    if (((unsigned int)$eflags >> 0xB) & 1)
+        set (unsigned int)$eflags = (unsigned int)$eflags&~0x800
     else
-        set $eflags = $eflags|0x800
+        set (unsigned int)$eflags = (unsigned int)$eflags|0x800
     end
 end
 document cfo


### PR DESCRIPTION
Hello,

I encountered a strange bug with gdb 7.4 while displaying the regs:
  RAX: 0x00007FFFE7F73F60  RBX: 0x000000C20004B0E0  RBP: 0x0000000000000040  RSP: 0x00007FFFE7F73EE0  Error while running hook_stop: Invalid cast.

Under gdb 7.3 it works fine:
gdb$ print $eflags
$1 = [ IF ]
gdb$ print ($eflags >> 0xB) & 1
$2 = 0x0

However under gdb 7.4.1-debian:
gdb$ print ($eflags >> 0xB) & 1
Invalid cast.

Making sure that $eflags is interpreted as an uint solves the problem:
gdb$ print ((unsigned int)$eflags >> 0xB) & 1
$4 = 0x0

Proposed patch replaces $eflags with (unsigned int)$eflags everywhere.
It now works on 7.4 as well as the old ones.

Cheers,
StalkR
