### PR TITLE
Remove path from nasm references

### DIFF
--- a/gdbinit
+++ b/gdbinit
@@ -3092,14 +3092,14 @@ define assemble
 	    if (sizeof(void *) == 8)
 		    # argument specified, assemble instructions into memory at address specified.
     		shell ASMOPCODE="$(while read -ep '>' r && test "$r" != end ; do echo -E "$r"; done)" ; GDBASMFILENAME=$RANDOM; \
-    		echo -e "BITS 64\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; /usr/local/bin/nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | /usr/bin/hexdump -ve '1/1 "set *((unsigned char *) $arg0 + %#2_ax) = %#02x\n"' >/tmp/gdbassemble ; /bin/rm -f /tmp/$GDBASMFILENAME
+    		echo -e "BITS 64\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | /usr/bin/hexdump -ve '1/1 "set *((unsigned char *) $arg0 + %#2_ax) = %#02x\n"' >/tmp/gdbassemble ; /bin/rm -f /tmp/$GDBASMFILENAME
     		source /tmp/gdbassemble
     		# all done. clean the temporary file
     		shell /bin/rm -f /tmp/gdbassemble
     	else
 	    	# argument specified, assemble instructions into memory at address specified.
 	    	shell ASMOPCODE="$(while read -ep '>' r && test "$r" != end ; do echo -E "$r"; done)" ; GDBASMFILENAME=$RANDOM; \
-		    echo -e "BITS 32\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; /usr/bin/nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | /usr/bin/hexdump -ve '1/1 "set *((unsigned char *) $arg0 + %#2_ax) = %#02x\n"' >/tmp/gdbassemble ; /bin/rm -f /tmp/$GDBASMFILENAME
+		    echo -e "BITS 32\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | /usr/bin/hexdump -ve '1/1 "set *((unsigned char *) $arg0 + %#2_ax) = %#02x\n"' >/tmp/gdbassemble ; /bin/rm -f /tmp/$GDBASMFILENAME
     		source /tmp/gdbassemble
 	    	# all done. clean the temporary file
 		    shell /bin/rm -f /tmp/gdbassemble
@@ -3108,12 +3108,12 @@ define assemble
 	    if (sizeof(void *) == 8)
 		    # no argument, assemble instructions to stdout
     		shell ASMOPCODE="$(while read -ep '>' r && test "$r" != end ; do echo -E "$r"; done)" ; GDBASMFILENAME=$RANDOM; \
-	    	echo -e "BITS 64\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; /usr/local/bin/nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | /usr/local/bin/ndisasm -i -b64 /dev/stdin ; \
+	    	echo -e "BITS 64\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | ndisasm -i -b64 /dev/stdin ; \
 		    /bin/rm -f /tmp/$GDBASMFILENAME
     	else
 	    	# no argument, assemble instructions to stdout
 	    	shell ASMOPCODE="$(while read -ep '>' r && test "$r" != end ; do echo -E "$r"; done)" ; GDBASMFILENAME=$RANDOM; \
-	    	echo -e "BITS 32\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; /usr/bin/nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | /usr/bin/ndisasm -i -b32 /dev/stdin ; \
+	    	echo -e "BITS 32\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | ndisasm -i -b32 /dev/stdin ; \
 		    /bin/rm -f /tmp/$GDBASMFILENAME
     	end
     end
@@ -3148,14 +3148,14 @@ define assemble32
     if ($argc)
         # argument specified, assemble instructions into memory at address specified.
         shell ASMOPCODE="$(while read -ep '>' r && test "$r" != end ; do echo -E "$r"; done)" ; GDBASMFILENAME=$RANDOM; \
-        echo -e "BITS 32\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; /usr/bin/nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | /usr/bin/hexdump -ve '1/1 "set *((unsigned char *) $arg0 + %#2_ax) = %#02x\n"' >/tmp/gdbassemble ; /bin/rm -f /tmp/$GDBASMFILENAME
+        echo -e "BITS 32\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | /usr/bin/hexdump -ve '1/1 "set *((unsigned char *) $arg0 + %#2_ax) = %#02x\n"' >/tmp/gdbassemble ; /bin/rm -f /tmp/$GDBASMFILENAME
         source /tmp/gdbassemble
         # all done. clean the temporary file
         shell /bin/rm -f /tmp/gdbassemble
     else
         # no argument, assemble instructions to stdout
         shell ASMOPCODE="$(while read -ep '>' r && test "$r" != end ; do echo -E "$r"; done)" ; GDBASMFILENAME=$RANDOM; \
-        echo -e "BITS 32\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; /usr/bin/nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | /usr/bin/ndisasm -i -b32 /dev/stdin ; \
+        echo -e "BITS 32\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | ndisasm -i -b32 /dev/stdin ; \
         /bin/rm -f /tmp/$GDBASMFILENAME
     end
 end
@@ -3189,14 +3189,14 @@ define assemble64
     if ($argc)
         # argument specified, assemble instructions into memory at address specified.
         shell ASMOPCODE="$(while read -ep '>' r && test "$r" != end ; do echo -E "$r"; done)" ; GDBASMFILENAME=$RANDOM; \
-        echo -e "BITS 64\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; /usr/local/bin/nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | /usr/bin/hexdump -ve '1/1 "set *((unsigned char *) $arg0 + %#2_ax) = %#02x\n"' >/tmp/gdbassemble ; /bin/rm -f /tmp/$GDBASMFILENAME
+        echo -e "BITS 64\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | /usr/bin/hexdump -ve '1/1 "set *((unsigned char *) $arg0 + %#2_ax) = %#02x\n"' >/tmp/gdbassemble ; /bin/rm -f /tmp/$GDBASMFILENAME
         source /tmp/gdbassemble
         # all done. clean the temporary file
         shell /bin/rm -f /tmp/gdbassemble
     else
         # no argument, assemble instructions to stdout
         shell ASMOPCODE="$(while read -ep '>' r && test "$r" != end ; do echo -E "$r"; done)" ; GDBASMFILENAME=$RANDOM; \
-        echo -e "BITS 64\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; /usr/local/bin/nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | /usr/local/bin/ndisasm -i -b64 /dev/stdin ; \
+        echo -e "BITS 64\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | ndisasm -i -b64 /dev/stdin ; \
         /bin/rm -f /tmp/$GDBASMFILENAME
     end
 end


### PR DESCRIPTION
Mac OS X seems to come with nasm in `/usr/bin` and I also have nasm from MacPorts in `/opt/local/bin`.

I don't know why you both reference `nasm` in both `/usr/bin` and `/usr/local/bin`, but it should now work with any path.
