### PR TITLE
Set prompt after sourcing .gdbinit.local.

### DIFF
--- a/gdbinit
+++ b/gdbinit
@@ -203,15 +203,15 @@ define color_underline
 	echo \033[4m
 end
 
-# can't use the color functions because we are using the set command
-if $COLOUREDPROMPT == 1
-	set prompt \033[31mgdb$ \033[0m
-end
-
 # this way anyone can have their custom prompt - argp's idea :-)
 # can also be used to redefine anything else in particular the colors aka theming
 # just remap the color variables defined above
 source ~/.gdbinit.local
+
+# can't use the color functions because we are using the set command
+if $COLOUREDPROMPT == 1
+	set prompt \033[31mgdb$ \033[0m
+end
 
 # Initialize these variables else comparisons will fail for colouring
 # we must initialize all of them at once, 32 and 64 bits, and ARM.


### PR DESCRIPTION
This patch makes it possible to `set $COLOUREDPROMPT = 0` in `.gdbinit.local`.
