### PR TITLE
remove absolute paths to rely on $PATH

### DIFF
--- a/gdbinit
+++ b/gdbinit
@@ -23,7 +23,7 @@
 #         An updated version of the patch and binary is available at http://reverse.put.as/2011/02/21/update-to-gdb-patches-fix-a-new-bug/
 #
 # iOS NOTES: iOS gdb from Cydia (and Apple's) suffer from the same OS X bug.
-#			 If you are using this on Mac OS X or iOS, you must either attach gdb to a process
+#            If you are using this on Mac OS X or iOS, you must either attach gdb to a process
 #            or launch gdb without any options and then load the binary file you want to analyse with "exec-file" option
 #            If you load the binary from the command line, like $gdb binary-name, this will not work as it should
 #            For more information, read it here http://reverse.put.as/2008/11/28/apples-gdb-bug/
@@ -38,16 +38,16 @@
 #     - Other fixes and additions from previous commits
 #
 #   Version 8.0.4 (08/05/2013)
-#     - Detect automatically 32 or 64 bits archs using sizeof(void*). 
+#     - Detect automatically 32 or 64 bits archs using sizeof(void*).
 #       Thanks to Tyilo for the simple but very effective idea!
 #     - Typo in hexdump command also fixed by vuquangtrong.
 #     - Add shortcuts to attach to VMware kernel debugging gdb stub (kernel32 and kernel64)
 #
 #   Version 8.0.3 (21/03/2013)
-#	  - Add option to colorize or not output (thanks to argp and skier for the request and ideas!)
-#     - Convert the escape codes into functions so colors can be easily customized
-#	  - Other enhancements available at git commit logs
-#       Thanks to Plouj, argp, xristos for their ideas and fixes!
+#      - Add option to colorize or not output (thanks to argp and skier for the request and ideas!)
+#      - Convert the escape codes into functions so colors can be easily customized
+#      - Other enhancements available at git commit logs
+#        Thanks to Plouj, argp, xristos for their ideas and fixes!
 #
 #   Version 8.0.2 (31/07/2012)
 #     - Merge pull request from mheistermann to support local modifications in a .gdbinit.local file
@@ -136,8 +136,8 @@ set $MAGENTA = 5
 set $CYAN = 6
 set $WHITE = 7
 
-# CHANGME: If you want to modify the "theme" change the colors here
-#          or just create a ~/.gdbinit.local and set these variables there
+# CHANGEME: If you want to modify the "theme" change the colors here
+#           or just create a ~/.gdbinit.local and set these variables there
 set $COLOR_REGNAME = $GREEN
 set $COLOR_REGVAL = $BLACK
 set $COLOR_REGVAL_MODIFIED  = $RED
@@ -146,64 +146,64 @@ set $COLOR_CPUFLAGS = $RED
 
 # this is ugly but there's no else if available :-(
 define color
- if $USECOLOR == 1
- 	# BLACK
- 	if $arg0 == 0
- 		echo \033[30m
- 	else
- 		# RED
-	 	if $arg0 == 1
-	 		echo \033[31m
-	 	else
-	 		# GREEN
-	 		if $arg0 == 2
-	 			echo \033[32m
-	 		else
-	 			# YELLOW
-	 			if $arg0 == 3
-	 				echo \033[33m
-	 			else
-	 				# BLUE
-	 				if $arg0 == 4
-	 					echo \033[34m
-	 				else
-	 					# MAGENTA
-	 					if $arg0 == 5
-	 						echo \033[35m
-	 					else
-	 						# CYAN
-	 						if $arg0 == 6
-	 							echo \033[36m
-	 						else
-	 							# WHITE
-	 							if $arg0 == 7
-	 								echo \033[37m
-	 							end
-	 						end
-	 					end
-	 				end
-	 			end
-	 		end
-	 	end
-	 end
- end
+    if $USECOLOR == 1
+        # BLACK
+        if $arg0 == 0
+            echo \033[30m
+        else
+            # RED
+            if $arg0 == 1
+                echo \033[31m
+            else
+                # GREEN
+                if $arg0 == 2
+                    echo \033[32m
+                else
+                    # YELLOW
+                    if $arg0 == 3
+                        echo \033[33m
+                    else
+                        # BLUE
+                        if $arg0 == 4
+                            echo \033[34m
+                        else
+                            # MAGENTA
+                            if $arg0 == 5
+                                echo \033[35m
+                            else
+                                # CYAN
+                                if $arg0 == 6
+                                    echo \033[36m
+                                else
+                                    # WHITE
+                                    if $arg0 == 7
+                                        echo \033[37m
+                                    end
+                                end
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
 end
 
 define color_reset
     if $USECOLOR == 1
-	   echo \033[0m
+        echo \033[0m
     end
 end
 
 define color_bold
     if $USECOLOR == 1
-	   echo \033[1m
+        echo \033[1m
     end
 end
 
 define color_underline
     if $USECOLOR == 1
-	   echo \033[4m
+        echo \033[4m
     end
 end
 
@@ -214,7 +214,7 @@ source ~/.gdbinit.local
 
 # can't use the color functions because we are using the set command
 if $COLOREDPROMPT == 1
-	set prompt \033[31mgdb$ \033[0m
+    set prompt \033[31mgdb$ \033[0m
 end
 
 # Initialize these variables else comparisons will fail for coloring
@@ -325,7 +325,7 @@ Syntax: bp LOCATION
 end
 
 
-define bpc 
+define bpc
     if $argc != 1
         help bpc
     else
@@ -469,26 +469,26 @@ define flagsarm
     # negative/less than (N), bit 31 of CPSR
     if (($cpsr >> 0x1f) & 1)
         printf "N "
-	    set $_n_flag = 1
+        set $_n_flag = 1
     else
         printf "n "
-	    set $_n_flag = 0
+        set $_n_flag = 0
     end
     # zero (Z), bit 30
     if (($cpsr >> 0x1e) & 1)
         printf "Z "
-	    set $_z_flag = 1
+        set $_z_flag = 1
     else
         printf "z "
-	    set $_z_flag = 0
+        set $_z_flag = 0
     end
     # Carry/Borrow/Extend (C), bit 29
     if (($cpsr >> 0x1d) & 1)
         printf "C "
-    	set $_c_flag = 1
+        set $_c_flag = 1
     else
         printf "c "
-	    set $_c_flag = 0
+        set $_c_flag = 0
     end
     # Overflow (V), bit 28
     if (($cpsr >> 0x1c) & 1)
@@ -498,7 +498,7 @@ define flagsarm
         printf "v "
         set $_v_flag = 0
     end
-    # Sticky overflow (Q), bit 27    
+    # Sticky overflow (Q), bit 27
     if (($cpsr >> 0x1b) & 1)
         printf "Q "
         set $_q_flag = 1
@@ -526,7 +526,7 @@ define flagsarm
         set $_e_flag = 0
     end
     # Imprecise abort disable bit (A), bit 8
-    # The A bit is set to 1 automatically. It is used to disable imprecise data aborts. 
+    # The A bit is set to 1 automatically. It is used to disable imprecise data aborts.
     # It might not be writable in the Nonsecure state if the AW bit in the SCR register is reset.
     if (($cpsr >> 8) & 1)
         printf "A "
@@ -545,7 +545,7 @@ define flagsarm
         set $_i_flag = 0
     end
     # FIQ disable bit (F), bit 6
-    # When the F bit is set to 1, FIQ interrupts are disabled. 
+    # When the F bit is set to 1, FIQ interrupts are disabled.
     # FIQ can be nonmaskable in the Nonsecure state if the FW bit in SCR register is reset.
     if (($cpsr >> 6) & 1)
         printf "F "
@@ -609,10 +609,10 @@ define flagsx86
     # ZF (zero) flag
     if (((unsigned int)$eflags >> 6) & 1)
         printf "Z "
-    	set $_zf_flag = 1
+        set $_zf_flag = 1
     else
         printf "z "
-	    set $_zf_flag = 0
+        set $_zf_flag = 0
     end
     # AF (adjust) flag
     if (((unsigned int)$eflags >> 4) & 1)
@@ -623,18 +623,18 @@ define flagsx86
     # PF (parity) flag
     if (((unsigned int)$eflags >> 2) & 1)
         printf "P "
-	    set $_pf_flag = 1
+        set $_pf_flag = 1
     else
         printf "p "
-    	set $_pf_flag = 0
+        set $_pf_flag = 0
     end
     # CF (carry) flag
     if ((unsigned int)$eflags & 1)
         printf "C "
-	    set $_cf_flag = 1
+        set $_cf_flag = 1
     else
         printf "c "
-    	set $_cf_flag = 0
+        set $_cf_flag = 0
     end
     printf "\n"
 end
@@ -692,7 +692,7 @@ end
 
 
 define cpsr
-	eflags
+    eflags
 end
 document cpsr
 Syntax: cpsr
@@ -719,7 +719,7 @@ define regarm
         color $COLOR_REGVAL
     end
     printf " 0x%08X  ", $r1
-	# R2
+    # R2
     color $COLOR_REGNAME
     printf "R2:"
     if ($r2 != $oldr2 && $SHOWREGCHANGES == 1)
@@ -728,7 +728,7 @@ define regarm
         color $COLOR_REGVAL
     end
     printf "  0x%08X  ", $r2
-	# R3
+    # R3
     color $COLOR_REGNAME
     printf "R3:"
     if ($r3 != $oldr3 && $SHOWREGCHANGES == 1)
@@ -738,7 +738,7 @@ define regarm
     end
     printf "  0x%08X\n", $r3
     printf "  "
-	# R4
+    # R4
     color $COLOR_REGNAME
     printf "R4:"
     if ($r4 != $oldr4 && $SHOWREGCHANGES == 1)
@@ -756,7 +756,7 @@ define regarm
         color $COLOR_REGVAL
     end
     printf " 0x%08X  ", $r5
-	# R6
+    # R6
     color $COLOR_REGNAME
     printf "R6:"
     if ($r6 != $oldr6 && $SHOWREGCHANGES == 1)
@@ -765,7 +765,7 @@ define regarm
         color $COLOR_REGVAL
     end
     printf "  0x%08X  ", $r6
-	# R7
+    # R7
     color $COLOR_REGNAME
     printf "R7:"
     if ($r7 != $oldr7 && $SHOWREGCHANGES == 1)
@@ -775,7 +775,7 @@ define regarm
     end
     printf "  0x%08X\n", $r7
     printf "  "
-	# R8
+    # R8
     color $COLOR_REGNAME
     printf "R8:"
     if ($r8 != $oldr8 && $SHOWREGCHANGES == 1)
@@ -784,7 +784,7 @@ define regarm
         color $COLOR_REGVAL
     end
     printf "  0x%08X  ", $r8
-	# R9
+    # R9
     color $COLOR_REGNAME
     printf "R9:"
     if ($r9 != $oldr9 && $SHOWREGCHANGES == 1)
@@ -793,7 +793,7 @@ define regarm
         color $COLOR_REGVAL
     end
     printf " 0x%08X  ", $r9
-	# R10
+    # R10
     color $COLOR_REGNAME
     printf "R10:"
     if ($r10 != $oldr10 && $SHOWREGCHANGES == 1)
@@ -802,7 +802,7 @@ define regarm
         color $COLOR_REGVAL
     end
     printf " 0x%08X  ", $r10
-	# R11
+    # R11
     color $COLOR_REGNAME
     printf "R11:"
     if ($r11 != $oldr11 && $SHOWREGCHANGES == 1)
@@ -832,7 +832,7 @@ define regarm
         color $COLOR_REGVAL
     end
     printf " 0x%08X  ", $sp
-	# LR
+    # LR
     color $COLOR_REGNAME
     printf "LR:"
     if ($lr != $oldlr && $SHOWREGCHANGES == 1)
@@ -841,7 +841,7 @@ define regarm
         color $COLOR_REGVAL
     end
     printf "  0x%08X  ", $lr
-	# PC
+    # PC
     color $COLOR_REGNAME
     printf "PC:"
     color $COLOR_REGVAL_MODIFIED
@@ -850,7 +850,7 @@ define regarm
     color_underline
     color $COLOR_CPUFLAGS
     flags
-	color_reset
+    color_reset
     printf "\n"
 end
 document regarm
@@ -907,36 +907,36 @@ define regx64
     color $COLOR_REGNAME
     printf "RDI:"
     if ($rdi != $oldrdi && $SHOWREGCHANGES == 1)
-	    color $COLOR_REGVAL_MODIFIED
-	else
-	    color $COLOR_REGVAL
-	end
-	printf " 0x%016lX  ", $rdi
-	# RSI
+        color $COLOR_REGVAL_MODIFIED
+    else
+        color $COLOR_REGVAL
+    end
+    printf " 0x%016lX  ", $rdi
+    # RSI
     color $COLOR_REGNAME
-   	printf "RSI:"
-	if ($rsi != $oldrsi && $SHOWREGCHANGES == 1)
-	    color $COLOR_REGVAL_MODIFIED
-	else
-	    color $COLOR_REGVAL
-	end
-	printf " 0x%016lX  ", $rsi
-	# RDX
+    printf "RSI:"
+    if ($rsi != $oldrsi && $SHOWREGCHANGES == 1)
+        color $COLOR_REGVAL_MODIFIED
+    else
+        color $COLOR_REGVAL
+    end
+    printf " 0x%016lX  ", $rsi
+    # RDX
     color $COLOR_REGNAME
-   	printf "RDX:"
-	if ($rdx != $oldrdx && $SHOWREGCHANGES == 1)
-	    color $COLOR_REGVAL_MODIFIED
-	else
-	    color $COLOR_REGVAL
-	end
-	printf " 0x%016lX  ", $rdx
-	# RCX
+    printf "RDX:"
+    if ($rdx != $oldrdx && $SHOWREGCHANGES == 1)
+        color $COLOR_REGVAL_MODIFIED
+    else
+        color $COLOR_REGVAL
+    end
+    printf " 0x%016lX  ", $rdx
+    # RCX
     color $COLOR_REGNAME
-   	printf "RCX:"
-	if ($rcx != $oldrcx && $SHOWREGCHANGES == 1)
-	    color $COLOR_REGVAL_MODIFIED
-	else
-	    color $COLOR_REGVAL
+    printf "RCX:"
+    if ($rcx != $oldrcx && $SHOWREGCHANGES == 1)
+        color $COLOR_REGVAL_MODIFIED
+    else
+        color $COLOR_REGVAL
     end
     printf " 0x%016lX  ", $rcx
     # RIP
@@ -946,77 +946,77 @@ define regx64
     printf " 0x%016lX\n  ", $rip
     # R8
     color $COLOR_REGNAME
-   	printf "R8 :"
-	if ($r8 != $oldr8 && $SHOWREGCHANGES == 1)
-	    color $COLOR_REGVAL_MODIFIED
-	else
-	    color $COLOR_REGVAL
+    printf "R8 :"
+    if ($r8 != $oldr8 && $SHOWREGCHANGES == 1)
+        color $COLOR_REGVAL_MODIFIED
+    else
+        color $COLOR_REGVAL
     end
     printf " 0x%016lX  ", $r8
     # R9
     color $COLOR_REGNAME
-   	printf "R9 :"
+    printf "R9 :"
     if ($r9 != $oldr9 && $SHOWREGCHANGES == 1)
-	    color $COLOR_REGVAL_MODIFIED
-	else
-	    color $COLOR_REGVAL
+        color $COLOR_REGVAL_MODIFIED
+    else
+        color $COLOR_REGVAL
     end
     printf " 0x%016lX  ", $r9
     # R10
     color $COLOR_REGNAME
-   	printf "R10:"
+    printf "R10:"
     if ($r10 != $oldr10 && $SHOWREGCHANGES == 1)
-	    color $COLOR_REGVAL_MODIFIED
-	else
-	    color $COLOR_REGVAL
+        color $COLOR_REGVAL_MODIFIED
+    else
+        color $COLOR_REGVAL
     end
     printf " 0x%016lX  ", $r10
     # R11
-   	color $COLOR_REGNAME
+    color $COLOR_REGNAME
     printf "R11:"
-	if ($r11 != $oldr11 && $SHOWREGCHANGES == 1)
-	    color $COLOR_REGVAL_MODIFIED
-	else
-	    color $COLOR_REGVAL
+    if ($r11 != $oldr11 && $SHOWREGCHANGES == 1)
+        color $COLOR_REGVAL_MODIFIED
+    else
+        color $COLOR_REGVAL
     end
     printf " 0x%016lX  ", $r11
     # R12
     color $COLOR_REGNAME
-	printf "R12:"
+    printf "R12:"
     if ($r12 != $oldr12 && $SHOWREGCHANGES == 1)
-	    color $COLOR_REGVAL_MODIFIED
-	else
-	    color $COLOR_REGVAL
+        color $COLOR_REGVAL_MODIFIED
+    else
+        color $COLOR_REGVAL
     end
     printf " 0x%016lX\n  ", $r12
     # R13
     color $COLOR_REGNAME
-   	printf "R13:"
+    printf "R13:"
     if ($r13 != $oldr13 && $SHOWREGCHANGES == 1)
-	    color $COLOR_REGVAL_MODIFIED
-	else
-	    color $COLOR_REGVAL
+        color $COLOR_REGVAL_MODIFIED
+    else
+        color $COLOR_REGVAL
     end
     printf " 0x%016lX  ", $r13
     # R14
     color $COLOR_REGNAME
     printf "R14:"
     if ($r14 != $oldr14 && $SHOWREGCHANGES == 1)
-	    color $COLOR_REGVAL_MODIFIED
-	else
-	    color $COLOR_REGVAL
+        color $COLOR_REGVAL_MODIFIED
+    else
+        color $COLOR_REGVAL
     end
     printf " 0x%016lX  ", $r14
     # R15
-	color $COLOR_REGNAME
+    color $COLOR_REGNAME
     printf "R15:"
     if ($r15 != $oldr15 && $SHOWREGCHANGES == 1)
-	    color $COLOR_REGVAL_MODIFIED
-	else
-	    color $COLOR_REGVAL
+        color $COLOR_REGVAL_MODIFIED
+    else
+        color $COLOR_REGVAL
     end
     printf " 0x%016lX\n  ", $r15
-  	color $COLOR_REGNAME
+    color $COLOR_REGNAME
     printf "CS:"
     color $COLOR_REGVAL
     printf " %04X  ", $cs
@@ -1052,80 +1052,80 @@ define regx86
     printf "  "
     # EAX
     color $COLOR_REGNAME
-	printf "EAX:"
+    printf "EAX:"
     if ($eax != $oldeax && $SHOWREGCHANGES == 1)
-   	 	color $COLOR_REGVAL_MODIFIED
-   	else
-   	 	color $COLOR_REGVAL
-   	end
-   	printf " 0x%08X  ", $eax
-   	# EBX
+        color $COLOR_REGVAL_MODIFIED
+    else
+        color $COLOR_REGVAL
+    end
+    printf " 0x%08X  ", $eax
+    # EBX
     color $COLOR_REGNAME
-   	printf "EBX:"
-   	if ($ebx != $oldebx && $SHOWREGCHANGES == 1) 
-	    color $COLOR_REGVAL_MODIFIED		
-   	else
-	    color $COLOR_REGVAL
-   	end
-   	printf " 0x%08X  ", $ebx
-   	# ECX
+    printf "EBX:"
+    if ($ebx != $oldebx && $SHOWREGCHANGES == 1)
+        color $COLOR_REGVAL_MODIFIED
+    else
+        color $COLOR_REGVAL
+    end
+    printf " 0x%08X  ", $ebx
+    # ECX
     color $COLOR_REGNAME
-   	printf "ECX:"
-   	if ($ecx != $oldecx && $SHOWREGCHANGES == 1)
-	    color $COLOR_REGVAL_MODIFIED
-	else
-	    color $COLOR_REGVAL
-	end
-	printf " 0x%08X  ", $ecx
-	# EDX
-	color $COLOR_REGNAME
-	printf "EDX:"
-	if ($edx != $oldedx && $SHOWREGCHANGES == 1)
-	    color $COLOR_REGVAL_MODIFIED
-	else
-	    color $COLOR_REGVAL
-	end
+    printf "ECX:"
+    if ($ecx != $oldecx && $SHOWREGCHANGES == 1)
+        color $COLOR_REGVAL_MODIFIED
+    else
+        color $COLOR_REGVAL
+    end
+    printf " 0x%08X  ", $ecx
+    # EDX
+    color $COLOR_REGNAME
+    printf "EDX:"
+    if ($edx != $oldedx && $SHOWREGCHANGES == 1)
+        color $COLOR_REGVAL_MODIFIED
+    else
+        color $COLOR_REGVAL
+    end
         printf " 0x%08X  ", $edx
-	color_bold
-	color_underline
-	color $COLOR_CPUFLAGS
+    color_bold
+    color_underline
+    color $COLOR_CPUFLAGS
     flags
     color_reset
     printf "  "
     # ESI
-	color $COLOR_REGNAME
+    color $COLOR_REGNAME
     printf "ESI:"
     if ($esi != $oldesi && $SHOWREGCHANGES == 1)
-	    color $COLOR_REGVAL_MODIFIED
-	else
-	    color $COLOR_REGVAL
-	end
-	printf " 0x%08X  ", $esi
-	# EDI
-	color $COLOR_REGNAME
+        color $COLOR_REGVAL_MODIFIED
+    else
+        color $COLOR_REGVAL
+    end
+    printf " 0x%08X  ", $esi
+    # EDI
+    color $COLOR_REGNAME
     printf "EDI:"
-	if ($edi != $oldedi && $SHOWREGCHANGES == 1)
-	    color $COLOR_REGVAL_MODIFIED
-	else
-	    color $COLOR_REGVAL
-	end
-	printf " 0x%08X  ", $edi
-	# EBP
-	color $COLOR_REGNAME
-	printf "EBP:"
-	if ($ebp != $oldebp && $SHOWREGCHANGES == 1)
-	    color $COLOR_REGVAL_MODIFIED
-	else
-	    color $COLOR_REGVAL
-	end
-	printf " 0x%08X  ", $ebp
-	# ESP
-	color $COLOR_REGNAME
+    if ($edi != $oldedi && $SHOWREGCHANGES == 1)
+        color $COLOR_REGVAL_MODIFIED
+    else
+        color $COLOR_REGVAL
+    end
+    printf " 0x%08X  ", $edi
+    # EBP
+    color $COLOR_REGNAME
+    printf "EBP:"
+    if ($ebp != $oldebp && $SHOWREGCHANGES == 1)
+        color $COLOR_REGVAL_MODIFIED
+    else
+        color $COLOR_REGVAL
+    end
+    printf " 0x%08X  ", $ebp
+    # ESP
+    color $COLOR_REGNAME
     printf "ESP:"
-	if ($esp != $oldesp && $SHOWREGCHANGES == 1)
-	    color $COLOR_REGVAL_MODIFIED
-	else
-	    color $COLOR_REGVAL
+    if ($esp != $oldesp && $SHOWREGCHANGES == 1)
+        color $COLOR_REGVAL_MODIFIED
+    else
+        color $COLOR_REGVAL
     end
     printf " 0x%08X  ", $esp
     # EIP
@@ -1168,23 +1168,23 @@ end
 define reg
     if $ARM == 1
         regarm
-	    if ($SHOWREGCHANGES == 1)
-	        set $oldr0  = $r0
-	        set $oldr1  = $r1
-	        set $oldr2  = $r2
-	        set $oldr3  = $r3
-	        set $oldr4  = $r4
-	        set $oldr5  = $r5
-	        set $oldr6  = $r6
-	        set $oldr7  = $r7
-	        set $oldr8  = $r8
-    		set $oldr9  = $r9
-	    	set $oldr10 = $r10
-		    set $oldr11 = $r11
-			set $oldr12 = $r12
-			set $oldsp  = $sp
-			set $oldlr  = $lr
-	    end
+        if ($SHOWREGCHANGES == 1)
+            set $oldr0  = $r0
+            set $oldr1  = $r1
+            set $oldr2  = $r2
+            set $oldr3  = $r3
+            set $oldr4  = $r4
+            set $oldr5  = $r5
+            set $oldr6  = $r6
+            set $oldr7  = $r7
+            set $oldr8  = $r8
+            set $oldr9  = $r9
+            set $oldr10 = $r10
+            set $oldr11 = $r11
+            set $oldr12 = $r12
+            set $oldsp  = $sp
+            set $oldlr  = $lr
+        end
     else
         if ($64BITS == 1)
             regx64
@@ -1192,42 +1192,42 @@ define reg
             regx86
         end
         # call smallregisters
-	    smallregisters
+        smallregisters
         # display conditional jump routine
-	    if ($64BITS == 1)
-    	    printf "\t\t\t\t"
-    	end
+        if ($64BITS == 1)
+            printf "\t\t\t\t"
+        end
         dumpjump
         printf "\n"
         if ($SHOWREGCHANGES == 1)
-    	    if ($64BITS == 1)
-	        	set $oldrax = $rax
-			    set $oldrbx = $rbx
-    			set $oldrcx = $rcx
-	    		set $oldrdx = $rdx
-		    	set $oldrsi = $rsi
-    			set $oldrdi = $rdi
-	    		set $oldrbp = $rbp
-		    	set $oldrsp = $rsp
-			    set $oldr8  = $r8
-    			set $oldr9  = $r9
-	    		set $oldr10 = $r10
-		    	set $oldr11 = $r11
-			    set $oldr12 = $r12
-    			set $oldr13 = $r13
-	    		set $oldr14 = $r14
-		    	set $oldr15 = $r15
-    		else
-	        	set $oldeax = $eax
-		    	set $oldebx = $ebx
-			    set $oldecx = $ecx
-    			set $oldedx = $edx
-	    		set $oldesi = $esi
-		    	set $oldedi = $edi
-			    set $oldebp = $ebp
-			    set $oldesp = $esp
-    		end
-	    end
+            if ($64BITS == 1)
+                set $oldrax = $rax
+                set $oldrbx = $rbx
+                set $oldrcx = $rcx
+                set $oldrdx = $rdx
+                set $oldrsi = $rsi
+                set $oldrdi = $rdi
+                set $oldrbp = $rbp
+                set $oldrsp = $rsp
+                set $oldr8  = $r8
+                set $oldr9  = $r9
+                set $oldr10 = $r10
+                set $oldr11 = $r11
+                set $oldr12 = $r12
+                set $oldr13 = $r13
+                set $oldr14 = $r14
+                set $oldr15 = $r15
+            else
+                set $oldeax = $eax
+                set $oldebx = $ebx
+                set $oldecx = $ecx
+                set $oldedx = $edx
+                set $oldesi = $esi
+                set $oldedi = $edi
+                set $oldebp = $ebp
+                set $oldesp = $esp
+            end
+        end
     end
 end
 document reg
@@ -1239,54 +1239,54 @@ end
 define smallregisters
     if ($64BITS == 1)
     #64bits stuff
-	    # from rax
-    	set $eax = $rax & 0xffffffff
-    	set $ax  = $rax & 0xffff
-    	set $al  = $ax & 0xff
-    	set $ah  = $ax >> 8
-    	# from rbx
-    	set $ebx = $rbx & 0xffffffff
-    	set $bx  = $rbx & 0xffff
-    	set $bl  = $bx & 0xff
-    	set $bh  = $bx >> 8
-	    # from rcx
-    	set $ecx = $rcx & 0xffffffff
-    	set $cx  = $rcx & 0xffff
-    	set $cl  = $cx & 0xff
-	    set $ch  = $cx >> 8
-    	# from rdx
-    	set $edx = $rdx & 0xffffffff
-    	set $dx  = $rdx & 0xffff
-    	set $dl  = $dx & 0xff
-    	set $dh  = $dx >> 8
-	    # from rsi
-    	set $esi = $rsi & 0xffffffff
-    	set $si  = $rsi & 0xffff
-    	# from rdi
-    	set $edi = $rdi & 0xffffffff
-    	set $di  = $rdi & 0xffff		
+        # from rax
+        set $eax = $rax & 0xffffffff
+        set $ax  = $rax & 0xffff
+        set $al  = $ax & 0xff
+        set $ah  = $ax >> 8
+        # from rbx
+        set $ebx = $rbx & 0xffffffff
+        set $bx  = $rbx & 0xffff
+        set $bl  = $bx & 0xff
+        set $bh  = $bx >> 8
+        # from rcx
+        set $ecx = $rcx & 0xffffffff
+        set $cx  = $rcx & 0xffff
+        set $cl  = $cx & 0xff
+        set $ch  = $cx >> 8
+        # from rdx
+        set $edx = $rdx & 0xffffffff
+        set $dx  = $rdx & 0xffff
+        set $dl  = $dx & 0xff
+        set $dh  = $dx >> 8
+        # from rsi
+        set $esi = $rsi & 0xffffffff
+        set $si  = $rsi & 0xffff
+        # from rdi
+        set $edi = $rdi & 0xffffffff
+        set $di  = $rdi & 0xffff
     #32 bits stuff
     else
-	    # from eax
-    	set $ax = $eax & 0xffff
-    	set $al = $ax & 0xff
-    	set $ah = $ax >> 8
-	    # from ebx
-    	set $bx = $ebx & 0xffff
-    	set $bl = $bx & 0xff
-    	set $bh = $bx >> 8
-    	# from ecx
-    	set $cx = $ecx & 0xffff
-    	set $cl = $cx & 0xff
-    	set $ch = $cx >> 8
-    	# from edx
-    	set $dx = $edx & 0xffff
-    	set $dl = $dx & 0xff
-	    set $dh = $dx >> 8
-    	# from esi
-    	set $si = $esi & 0xffff
-    	# from edi
-	    set $di = $edi & 0xffff		
+        # from eax
+        set $ax = $eax & 0xffff
+        set $al = $ax & 0xff
+        set $ah = $ax >> 8
+        # from ebx
+        set $bx = $ebx & 0xffff
+        set $bl = $bx & 0xff
+        set $bh = $bx >> 8
+        # from ecx
+        set $cx = $ecx & 0xffff
+        set $cl = $cx & 0xff
+        set $ch = $cx >> 8
+        # from edx
+        set $dx = $edx & 0xffff
+        set $dl = $dx & 0xff
+        set $dh = $dx >> 8
+        # from esi
+        set $si = $esi & 0xffff
+        # from edi
+        set $di = $edi & 0xffff
      end
 end
 document smallregisters
@@ -1375,7 +1375,7 @@ define dis
     end
     if $argc == 2
         disassemble $arg0 $arg1
-    end 
+    end
     if $argc > 2
         help dis
     end
@@ -1383,7 +1383,7 @@ end
 document dis
 Syntax: dis <ADDR1> <ADDR2>
 | Disassemble a specified section of memory.
-| Default is to disassemble the function surrounding the PC (program counter) of selected frame. 
+| Default is to disassemble the function surrounding the PC (program counter) of selected frame.
 | With one argument, ADDR1, the function surrounding this address is dumped.
 | Two arguments are taken as a range of memory to dump.
 end
@@ -1430,23 +1430,23 @@ end
 define hexdump
     if $argc == 1
         hexdump_aux $arg0
-	else
-		if $argc == 2
-			set $_count = 0
-			while ($_count < $arg1)
-				set $_i = ($_count * 0x10)
-				hexdump_aux $arg0+$_i
-				set $_count++
-			end
-		else
-			help hexdump
-		end
+    else
+        if $argc == 2
+            set $_count = 0
+            while ($_count < $arg1)
+                set $_i = ($_count * 0x10)
+                hexdump_aux $arg0+$_i
+                set $_count++
+            end
+        else
+            help hexdump
+        end
     end
 end
 document hexdump
 Syntax: hexdump ADDR <NR_LINES>
 | Display a 16-byte hex/ASCII dump of memory starting at address ADDR.
-| Optional parameter is the number of lines to display if you want more than one. 
+| Optional parameter is the number of lines to display if you want more than one.
 end
 
 
@@ -1454,7 +1454,7 @@ define hexdump_aux
     if $argc != 1
         help hexdump_aux
     else
-    	color_bold
+        color_bold
         if ($64BITS == 1)
             printf "0x%016lX : ", $arg0
         else
@@ -1510,15 +1510,15 @@ define ddump
             end
         end
 
-    	color $COLOR_SEPARATOR
-    	printf "------------------------"
+        color $COLOR_SEPARATOR
+        printf "------------------------"
         printf "-------------------------------"
         if ($64BITS == 1)
             printf "-------------------------------------"
-	    end
-	    color_bold
-	    color $COLOR_SEPARATOR
-	    printf "[data]\n"
+        end
+        color_bold
+        color $COLOR_SEPARATOR
+        printf "[data]\n"
         color_reset
         set $_count = 0
         while ($_count < $arg0)
@@ -1628,21 +1628,21 @@ define dumpjump
         end
 
         if $_t_flag == 0
-	        set $_lastbyte = *(unsigned char *)($pc+3)
-	        #set $_bit31 = ($_lastbyte >> 7) & 1
-        	#set $_bit30 = ($_lastbyte >> 6) & 1
-    	    #set $_bit29 = ($_lastbyte >> 5) & 1
-    	    #set $_bit28 = ($_lastbyte >> 4) & 1
-    	    set $_conditional = $_lastbyte >> 4
-        	dumpjumphelper
+            set $_lastbyte = *(unsigned char *)($pc+3)
+            #set $_bit31 = ($_lastbyte >> 7) & 1
+            #set $_bit30 = ($_lastbyte >> 6) & 1
+            #set $_bit29 = ($_lastbyte >> 5) & 1
+            #set $_bit28 = ($_lastbyte >> 4) & 1
+            set $_conditional = $_lastbyte >> 4
+            dumpjumphelper
         else
-        	# if bits 15-12 (opcode in Thumb instructions) are equal to 1 1 0 1 (0xD) then we have a conditional branch
-        	# bits 11-8 for the conditional execution code (check ARMv7 manual A8.3)
-        	if ( (*(unsigned char *)($pc+1) >> 4) == 0xD )
-	        	set $_conditional = *(unsigned char *)($pc+1) ^ 0xD0
-        		dumpjumphelper
-        	end
-        end 
+            # if bits 15-12 (opcode in Thumb instructions) are equal to 1 1 0 1 (0xD) then we have a conditional branch
+            # bits 11-8 for the conditional execution code (check ARMv7 manual A8.3)
+            if ( (*(unsigned char *)($pc+1) >> 4) == 0xD )
+                set $_conditional = *(unsigned char *)($pc+1) ^ 0xD0
+                dumpjumphelper
+            end
+        end
 ##################### X86
     else
         ## grab the first two bytes from the instruction so we can determine the jump instruction
@@ -1654,217 +1654,217 @@ define dumpjump
         ## opcode 0x77: JA, JNBE (jump if CF=0 and ZF=0)
         ## opcode 0x0F87: JNBE, JA
         if ( ($_byte1 == 0x77) || ($_byte1 == 0x0F && $_byte2 == 0x87) )
-         	# cf=0 and zf=0
- 	        if ($_cf_flag == 0 && $_zf_flag == 0)
-	        	color $RED
-           		printf "  Jump is taken (c=0 and z=0)"
-          	else
-            	# cf != 0 or zf != 0
-           		color $RED
-           		printf "  Jump is NOT taken (c!=0 or z!=0)"
-          	end 
+            # cf=0 and zf=0
+            if ($_cf_flag == 0 && $_zf_flag == 0)
+                color $RED
+                printf "  Jump is taken (c=0 and z=0)"
+            else
+                # cf != 0 or zf != 0
+                color $RED
+                printf "  Jump is NOT taken (c!=0 or z!=0)"
+            end
         end
         ## opcode 0x73: JAE, JNB, JNC (jump if CF=0)
         ## opcode 0x0F83: JNC, JNB, JAE (jump if CF=0)
         if ( ($_byte1 == 0x73) || ($_byte1 == 0x0F && $_byte2 == 0x83) )
-         	# cf=0
-         	if ($_cf_flag == 0)
-		        color $RED
-           		printf "  Jump is taken (c=0)"
-          	else
-            	# cf != 0
-           		color $RED
-   		        printf "  Jump is NOT taken (c!=0)"
-          	end 
+            # cf=0
+            if ($_cf_flag == 0)
+                color $RED
+                printf "  Jump is taken (c=0)"
+            else
+                # cf != 0
+                color $RED
+                printf "  Jump is NOT taken (c!=0)"
+            end
         end
         ## opcode 0x72: JB, JC, JNAE (jump if CF=1)
         ## opcode 0x0F82: JNAE, JB, JC
         if ( ($_byte1 == 0x72) || ($_byte1 == 0x0F && $_byte2 == 0x82) )
             # cf=1
- 	        if ($_cf_flag == 1)
-		        color $RED
-        		printf "  Jump is taken (c=1)"
-          	else
-            	# cf != 1
-           		color $RED
-   		        printf "  Jump is NOT taken (c!=1)"
-          	end 
+            if ($_cf_flag == 1)
+                color $RED
+                printf "  Jump is taken (c=1)"
+            else
+                # cf != 1
+                color $RED
+                printf "  Jump is NOT taken (c!=1)"
+            end
         end
         ## opcode 0x76: JBE, JNA (jump if CF=1 or ZF=1)
         ## opcode 0x0F86: JBE, JNA
         if ( ($_byte1 == 0x76) || ($_byte1 == 0x0F && $_byte2 == 0x86) )
-         	# cf=1 or zf=1
-         	if (($_cf_flag == 1) || ($_zf_flag == 1))
-		        color $RED
-           		printf "  Jump is taken (c=1 or z=1)"
-          	else
-            	# cf != 1 or zf != 1
-           		color $RED
-           		printf "  Jump is NOT taken (c!=1 or z!=1)"
-          	end 
+            # cf=1 or zf=1
+            if (($_cf_flag == 1) || ($_zf_flag == 1))
+                color $RED
+                printf "  Jump is taken (c=1 or z=1)"
+            else
+                # cf != 1 or zf != 1
+                color $RED
+                printf "  Jump is NOT taken (c!=1 or z!=1)"
+            end
         end
         ## opcode 0xE3: JCXZ, JECXZ, JRCXZ (jump if CX=0 or ECX=0 or RCX=0)
         if ($_byte1 == 0xE3)
-         	# cx=0 or ecx=0
-         	if (($ecx == 0) || ($cx == 0))
-        		color $RED
-   		        printf "  Jump is taken (cx=0 or ecx=0)"
-          	else
-   	    	    color $RED
-       	    	printf "  Jump is NOT taken (cx!=0 or ecx!=0)"
-          	end 
+            # cx=0 or ecx=0
+            if (($ecx == 0) || ($cx == 0))
+                color $RED
+                printf "  Jump is taken (cx=0 or ecx=0)"
+            else
+                color $RED
+                printf "  Jump is NOT taken (cx!=0 or ecx!=0)"
+            end
         end
         ## opcode 0x74: JE, JZ (jump if ZF=1)
         ## opcode 0x0F84: JZ, JE, JZ (jump if ZF=1)
         if ( ($_byte1 == 0x74) || ($_byte1 == 0x0F && $_byte2 == 0x84) )
-             # ZF = 1
-          	if ($_zf_flag == 1)
-   		        color $RED
-           		printf "  Jump is taken (z=1)"
-          	else
+            # ZF = 1
+            if ($_zf_flag == 1)
+                color $RED
+                printf "  Jump is taken (z=1)"
+            else
                 # ZF = 0
-           		color $RED
-   		        printf "  Jump is NOT taken (z!=1)"
-          	end 
+                color $RED
+                printf "  Jump is NOT taken (z!=1)"
+            end
         end
         ## opcode 0x7F: JG, JNLE (jump if ZF=0 and SF=OF)
         ## opcode 0x0F8F: JNLE, JG (jump if ZF=0 and SF=OF)
         if ( ($_byte1 == 0x7F) || ($_byte1 == 0x0F && $_byte2 == 0x8F) )
             # zf = 0 and sf = of
-  	        if (($_zf_flag == 0) && ($_sf_flag == $_of_flag))
-   		        color $RED
-   		        printf "  Jump is taken (z=0 and s=o)"
-         	else
-   		        color $RED
-   		        printf "  Jump is NOT taken (z!=0 or s!=o)"
-  	        end 
+            if (($_zf_flag == 0) && ($_sf_flag == $_of_flag))
+                color $RED
+                printf "  Jump is taken (z=0 and s=o)"
+            else
+                color $RED
+                printf "  Jump is NOT taken (z!=0 or s!=o)"
+            end
         end
         ## opcode 0x7D: JGE, JNL (jump if SF=OF)
         ## opcode 0x0F8D: JNL, JGE (jump if SF=OF)
         if ( ($_byte1 == 0x7D) || ($_byte1 == 0x0F && $_byte2 == 0x8D) )
             # sf = of
-  	        if ($_sf_flag == $_of_flag)
-   		        color $RED
-   		        printf "  Jump is taken (s=o)"
-  	        else
-   		        color $RED
-   		        printf "  Jump is NOT taken (s!=o)"
-  	        end 
+            if ($_sf_flag == $_of_flag)
+                color $RED
+                printf "  Jump is taken (s=o)"
+            else
+                color $RED
+                printf "  Jump is NOT taken (s!=o)"
+            end
         end
         ## opcode: 0x7C: JL, JNGE (jump if SF != OF)
         ## opcode: 0x0F8C: JNGE, JL (jump if SF != OF)
         if ( ($_byte1 == 0x7C) || ($_byte1 == 0x0F && $_byte2 == 0x8C) )
             # sf != of
-  	        if ($_sf_flag != $_of_flag)
-   		        color $RED
-   		        printf "  Jump is taken (s!=o)"
-  	        else
-        		color $RED
-   		        printf "  Jump is NOT taken (s=o)"
-  	        end 
+            if ($_sf_flag != $_of_flag)
+                color $RED
+                printf "  Jump is taken (s!=o)"
+            else
+                color $RED
+                printf "  Jump is NOT taken (s=o)"
+            end
         end
         ## opcode 0x7E: JLE, JNG (jump if ZF = 1 or SF != OF)
         ## opcode 0x0F8E: JNG, JLE (jump if ZF = 1 or SF != OF)
         if ( ($_byte1 == 0x7E) || ($_byte1 == 0x0F && $_byte2 == 0x8E) )
             # zf = 1 or sf != of
-        	if (($_zf_flag == 1) || ($_sf_flag != $_of_flag))
-   	        	color $RED
-   		        printf "  Jump is taken (zf=1 or sf!=of)"
-  	        else
-   		        color $RED
-   	        	printf "  Jump is NOT taken (zf!=1 or sf=of)"
-  	        end 
+            if (($_zf_flag == 1) || ($_sf_flag != $_of_flag))
+                color $RED
+                printf "  Jump is taken (zf=1 or sf!=of)"
+            else
+                color $RED
+                printf "  Jump is NOT taken (zf!=1 or sf=of)"
+            end
         end
         ## opcode 0x75: JNE, JNZ (jump if ZF = 0)
         ## opcode 0x0F85: JNE, JNZ (jump if ZF = 0)
         if ( ($_byte1 == 0x75) || ($_byte1 == 0x0F && $_byte2 == 0x85) )
             # ZF = 0
-  	        if ($_zf_flag == 0)
-   		        color $RED
-        		printf "  Jump is taken (z=0)"
-  	        else
+            if ($_zf_flag == 0)
+                color $RED
+                printf "  Jump is taken (z=0)"
+            else
                 # ZF = 1
-   		        color $RED
-   	        	printf "  Jump is NOT taken (z!=0)"
-  	        end 
+                color $RED
+                printf "  Jump is NOT taken (z!=0)"
+            end
         end
         ## opcode 0x71: JNO (OF = 0)
         ## opcode 0x0F81: JNO (OF = 0)
         if ( ($_byte1 == 0x71) || ($_byte1 == 0x0F && $_byte2 == 0x81) )
             # OF = 0
-	        if ($_of_flag == 0)
-   		        color $RED
-   	        	printf "  Jump is taken (o=0)"
-	        else
+            if ($_of_flag == 0)
+                color $RED
+                printf "  Jump is taken (o=0)"
+            else
                 # OF != 0
-           		color $RED
-           		printf "  Jump is NOT taken (o!=0)"
-          	end 
+                color $RED
+                printf "  Jump is NOT taken (o!=0)"
+            end
         end
         ## opcode 0x7B: JNP, JPO (jump if PF = 0)
         ## opcode 0x0F8B: JPO (jump if PF = 0)
         if ( ($_byte1 == 0x7B) || ($_byte1 == 0x0F && $_byte2 == 0x8B) )
-             # PF = 0
-          	if ($_pf_flag == 0)
-           		color $RED
-           		printf "  Jump is NOT taken (p=0)"
-          	else
+            # PF = 0
+            if ($_pf_flag == 0)
+                color $RED
+                printf "  Jump is NOT taken (p=0)"
+            else
                 # PF != 0
-           		color $RED
-   		        printf "  Jump is taken (p!=0)"
-          	end 
+                color $RED
+                printf "  Jump is taken (p!=0)"
+            end
         end
         ## opcode 0x79: JNS (jump if SF = 0)
         ## opcode 0x0F89: JNS (jump if SF = 0)
         if ( ($_byte1 == 0x79) || ($_byte1 == 0x0F && $_byte2 == 0x89) )
-             # SF = 0
-          	if ($_sf_flag == 0)
-   		        color $RED
-           		printf "  Jump is taken (s=0)"
-          	else
-                 # SF != 0
-           		color $RED
-   		        printf "  Jump is NOT taken (s!=0)"
-          	end 
+            # SF = 0
+            if ($_sf_flag == 0)
+                color $RED
+                printf "  Jump is taken (s=0)"
+            else
+                # SF != 0
+                color $RED
+                printf "  Jump is NOT taken (s!=0)"
+            end
         end
         ## opcode 0x70: JO (jump if OF=1)
         ## opcode 0x0F80: JO (jump if OF=1)
         if ( ($_byte1 == 0x70) || ($_byte1 == 0x0F && $_byte2 == 0x80) )
-             # OF = 1
-        	if ($_of_flag == 1)
-        		color $RED
-   		        printf "  Jump is taken (o=1)"
-          	else
+            # OF = 1
+            if ($_of_flag == 1)
+                color $RED
+                printf "  Jump is taken (o=1)"
+            else
                 # OF != 1
-           		color $RED
-   		        printf "  Jump is NOT taken (o!=1)"
-          	end 
+                color $RED
+                printf "  Jump is NOT taken (o!=1)"
+            end
         end
         ## opcode 0x7A: JP, JPE (jump if PF=1)
         ## opcode 0x0F8A: JP, JPE (jump if PF=1)
         if ( ($_byte1 == 0x7A) || ($_byte1 == 0x0F && $_byte2 == 0x8A) )
             # PF = 1
-          	if ($_pf_flag == 1)
-   		        color $RED
-           		printf "  Jump is taken (p=1)"
-          	else
-                 # PF = 0
-           		color $RED
-   		        printf "  Jump is NOT taken (p!=1)"
-          	end 
+            if ($_pf_flag == 1)
+                color $RED
+                printf "  Jump is taken (p=1)"
+            else
+                # PF = 0
+                color $RED
+                printf "  Jump is NOT taken (p!=1)"
+            end
         end
         ## opcode 0x78: JS (jump if SF=1)
         ## opcode 0x0F88: JS (jump if SF=1)
         if ( ($_byte1 == 0x78) || ($_byte1 == 0x0F && $_byte2 == 0x88) )
-             # SF = 1
-        	if ($_sf_flag == 1)
-   		        color $RED
-           		printf "  Jump is taken (s=1)"
-          	else
-                 # SF != 1
-           		color $RED
-           		printf "  Jump is NOT taken (s!=1)"
-          	end 
+            # SF = 1
+            if ($_sf_flag == 1)
+                color $RED
+                printf "  Jump is taken (s=1)"
+            else
+                # SF != 1
+                color $RED
+                printf "  Jump is NOT taken (s!=1)"
+            end
         end
     end
 end
@@ -1876,143 +1876,143 @@ end
 define dumpjumphelper
     # 0000 - EQ: Z == 1
     if ($_conditional == 0x0)
-	    if ($_z_flag == 1)
-		    color $RED
-    		printf " Jump is taken (z==1)"
-    	else
-	    	color $RED
-    		printf " Jump is NOT taken (z!=1)"
-    	end
+        if ($_z_flag == 1)
+            color $RED
+            printf " Jump is taken (z==1)"
+        else
+            color $RED
+            printf " Jump is NOT taken (z!=1)"
+        end
     end
     # 0001 - NE: Z == 0
     if ($_conditional == 0x1)
-	    if ($_z_flag == 0)
-		    color $RED
-    		printf " Jump is taken (z==0)"
-	    else
-		    color $RED
-    		printf " Jump is NOT taken (z!=0)"
-	    end
+        if ($_z_flag == 0)
+            color $RED
+            printf " Jump is taken (z==0)"
+        else
+            color $RED
+            printf " Jump is NOT taken (z!=0)"
+        end
     end
     # 0010 - CS: C == 1
     if ($_conditional == 0x2)
-	    if ($_c_flag == 1)
-		    color $RED
-    		printf " Jump is taken (c==1)"
-	    else
-		    color $RED
-    		printf " Jump is NOT taken (c!=1)"
-	    end
+        if ($_c_flag == 1)
+            color $RED
+            printf " Jump is taken (c==1)"
+        else
+            color $RED
+            printf " Jump is NOT taken (c!=1)"
+        end
     end
     # 0011 - CC: C == 0
     if ($_conditional == 0x3)
-	    if ($_c_flag == 0)
-		    color $RED
-    		printf " Jump is taken (c==0)"
-	    else
-		    color $RED
-    		printf " Jump is NOT taken (c!=0)"
-	    end
+        if ($_c_flag == 0)
+            color $RED
+            printf " Jump is taken (c==0)"
+        else
+            color $RED
+            printf " Jump is NOT taken (c!=0)"
+        end
     end
     # 0100 - MI: N == 1
     if ($_conditional == 0x4)
-	    if ($_n_flag == 1)
-		    color $RED
-	    	printf " Jump is taken (n==1)"
-    	else
-		    color $RED
-    		printf " Jump is NOT taken (n!=1)"
-	    end
+        if ($_n_flag == 1)
+            color $RED
+            printf " Jump is taken (n==1)"
+        else
+            color $RED
+            printf " Jump is NOT taken (n!=1)"
+        end
     end
     # 0101 - PL: N == 0
     if ($_conditional == 0x5)
-	    if ($_n_flag == 0)
-		    color $RED
-    		printf " Jump is taken (n==0)"
-	    else
-		    color $RED
-    		printf " Jump is NOT taken (n!=0)"
-	    end
+        if ($_n_flag == 0)
+            color $RED
+            printf " Jump is taken (n==0)"
+        else
+            color $RED
+            printf " Jump is NOT taken (n!=0)"
+        end
     end
     # 0110 - VS: V == 1
     if ($_conditional == 0x6)
-	    if ($_v_flag == 1)
-		    color $RED
-    		printf " Jump is taken (v==1)"
-	    else
-		    color $RED
-    		printf " Jump is NOT taken (v!=1)"
-	    end
+        if ($_v_flag == 1)
+            color $RED
+            printf " Jump is taken (v==1)"
+        else
+            color $RED
+            printf " Jump is NOT taken (v!=1)"
+        end
     end
     # 0111 - VC: V == 0
     if ($_conditional == 0x7)
-	    if ($_v_flag == 0)
-		    color $RED
-        	printf " Jump is taken (v==0)"
-    	else
-	    	color $RED
-    		printf " Jump is NOT taken (v!=0)"
-	    end
+        if ($_v_flag == 0)
+            color $RED
+            printf " Jump is taken (v==0)"
+        else
+            color $RED
+            printf " Jump is NOT taken (v!=0)"
+        end
     end
     # 1000 - HI: C == 1 and Z == 0
     if ($_conditional == 0x8)
-	    if ($_c_flag == 1 && $_z_flag == 0)
-		    color $RED
-        	printf " Jump is taken (c==1 and z==0)"
-    	else
-	    	color $RED
-    		printf " Jump is NOT taken (c!=1 or z!=0)"
-    	end
+        if ($_c_flag == 1 && $_z_flag == 0)
+            color $RED
+            printf " Jump is taken (c==1 and z==0)"
+        else
+            color $RED
+            printf " Jump is NOT taken (c!=1 or z!=0)"
+        end
     end
     # 1001 - LS: C == 0 or Z == 1
     if ($_conditional == 0x9)
-	    if ($_c_flag == 0 || $_z_flag == 1)
-		    color $RED
-    		printf " Jump is taken (c==0 or z==1)"
-	    else
-    		color $RED
-    		printf " Jump is NOT taken (c!=0 or z!=1)"
-	    end
+        if ($_c_flag == 0 || $_z_flag == 1)
+            color $RED
+            printf " Jump is taken (c==0 or z==1)"
+        else
+            color $RED
+            printf " Jump is NOT taken (c!=0 or z!=1)"
+        end
     end
     # 1010 - GE: N == V
     if ($_conditional == 0xA)
-	    if ($_n_flag == $_v_flag)
-		    color $RED
-        	printf " Jump is taken (n==v)"
-    	else
-	    	color $RED
-    		printf " Jump is NOT taken (n!=v)"
-    	end
+        if ($_n_flag == $_v_flag)
+            color $RED
+            printf " Jump is taken (n==v)"
+        else
+            color $RED
+            printf " Jump is NOT taken (n!=v)"
+        end
     end
     # 1011 - LT: N != V
     if ($_conditional == 0xB)
-	    if ($_n_flag != $_v_flag)
-		    color $RED
-    		printf " Jump is taken (n!=v)"
-	    else
-		    color $RED
-    		printf " Jump is NOT taken (n==v)"
-	    end
+        if ($_n_flag != $_v_flag)
+            color $RED
+            printf " Jump is taken (n!=v)"
+        else
+            color $RED
+            printf " Jump is NOT taken (n==v)"
+        end
     end
     # 1100 - GT: Z == 0 and N == V
     if ($_conditional == 0xC)
-	    if ($_z_flag == 0 && $_n_flag == $_v_flag)
-		    color $RED
-    		printf " Jump is taken (z==0 and n==v)"
-	    else
-		    color $RED
-    		printf " Jump is NOT taken (z!=0 or n!=v)"
-	    end
+        if ($_z_flag == 0 && $_n_flag == $_v_flag)
+            color $RED
+            printf " Jump is taken (z==0 and n==v)"
+        else
+            color $RED
+            printf " Jump is NOT taken (z!=0 or n!=v)"
+        end
     end
     # 1101 - LE: Z == 1 or N != V
     if ($_conditional == 0xD)
-	    if ($_z_flag == 1 || $_n_flag != $_v_flag)
-		    color $RED
-    		printf " Jump is taken (z==1 or n!=v)"
-	    else
-		    color $RED
-    		printf " Jump is NOT taken (z!=1 or n==v)"
-	    end
+        if ($_z_flag == 1 || $_n_flag != $_v_flag)
+            color $RED
+            printf " Jump is taken (z==1 or n!=v)"
+        else
+            color $RED
+            printf " Jump is NOT taken (z!=1 or n==v)"
+        end
     end
 end
 document dumpjumphelper
@@ -2025,48 +2025,48 @@ end
 # initialize variable
 set $displayobjectivec = 0
 
-define context 
+define context
     color $COLOR_SEPARATOR
     if $SHOWCPUREGISTERS == 1
-	    printf "----------------------------------------"
-	    printf "----------------------------------"
-	    if ($64BITS == 1)
-	        printf "---------------------------------------------"
-	    end
-	    color $COLOR_SEPARATOR
-	    color_bold
-	    printf "[regs]\n"
-	    color_reset
-	    reg
-	    color $CYAN
+        printf "----------------------------------------"
+        printf "----------------------------------"
+        if ($64BITS == 1)
+            printf "---------------------------------------------"
+        end
+        color $COLOR_SEPARATOR
+        color_bold
+        printf "[regs]\n"
+        color_reset
+        reg
+        color $CYAN
     end
     if $SHOWSTACK == 1
-    	color $COLOR_SEPARATOR
-		if $ARM == 1
-       printf "[0x%08X]", $sp
-		else
-        if ($64BITS == 1)
-		        printf "[0x%04X:0x%016lX]", $ss, $rsp
-        else
-            printf "[0x%04X:0x%08X]", $ss, $esp
-        end
-    end
         color $COLOR_SEPARATOR
-		printf "-------------------------"
-    	printf "-----------------------------"
-	    if ($64BITS == 1)
-	        printf "-------------------------------------"
-	    end
-	    color $COLOR_SEPARATOR
-	    color_bold
-	    printf "[stack]\n"
-    	color_reset
-    	set $context_i = $CONTEXTSIZE_STACK
-    	while ($context_i > 0)
-       	    set $context_t = $sp + 0x10 * ($context_i - 1)
-       	    hexdump $context_t
-       	    set $context_i--
-    	end
+        if $ARM == 1
+            printf "[0x%08X]", $sp
+        else
+            if ($64BITS == 1)
+                printf "[0x%04X:0x%016lX]", $ss, $rsp
+            else
+                printf "[0x%04X:0x%08X]", $ss, $esp
+            end
+        end
+        color $COLOR_SEPARATOR
+        printf "-------------------------"
+        printf "-----------------------------"
+        if ($64BITS == 1)
+            printf "-------------------------------------"
+        end
+        color $COLOR_SEPARATOR
+        color_bold
+        printf "[stack]\n"
+        color_reset
+        set $context_i = $CONTEXTSIZE_STACK
+        while ($context_i > 0)
+            set $context_t = $sp + 0x10 * ($context_i - 1)
+            hexdump $context_t
+            set $context_i--
+        end
     end
     # show the objective C message being passed to msgSend
     if $SHOWOBJECTIVEC == 1
@@ -2075,21 +2075,21 @@ define context
         # detect if it's the correct opcode we are searching for
         if $ARM == 0
             set $__byte1 = *(unsigned char *)$pc
-    	    set $__byte = *(int *)$pc
-        	if ($__byte == 0x4244489)
-          		set $objectivec = $eax
-      	    	set $displayobjectivec = 1
-    	    end
+            set $__byte = *(int *)$pc
+            if ($__byte == 0x4244489)
+                set $objectivec = $eax
+                set $displayobjectivec = 1
+            end
 
-        	if ($__byte == 0x4245489)
-         		set $objectivec = $edx
-     	    	set $displayobjectivec = 1
-    	    end
+            if ($__byte == 0x4245489)
+                set $objectivec = $edx
+                set $displayobjectivec = 1
+            end
 
-        	if ($__byte == 0x4244c89)
-         		set $objectivec = $ecx
-     	    	set $displayobjectivec = 1
-        	end
+            if ($__byte == 0x4244c89)
+                set $objectivec = $ecx
+                set $displayobjectivec = 1
+            end
         else
             set $__byte1 = 0
         end
@@ -2103,29 +2103,29 @@ define context
                 end
                 color $COLOR_SEPARATOR
                 color_bold
-	    		printf "[ObjectiveC]\n"
-	    		color_reset
-      	    	color $BLACK
-      		    x/s $objectivec
-         	end   
-         	set $displayobjectivec = 0     
+                printf "[ObjectiveC]\n"
+                color_reset
+                color $BLACK
+                x/s $objectivec
+            end
+            set $displayobjectivec = 0
         end
         if $displayobjectivec == 1
             color $COLOR_SEPARATOR
-          	printf "--------------------------------------------------------------------"
-          	if ($64BITS == 1)
-	            printf "---------------------------------------------"
-    	    end
-    	    color $COLOR_SEPARATOR
-    	    color_bold
-		    printf "[ObjectiveC]\n"
-		    color_reset
-          	color $BLACK
-          	x/s $objectivec 
-        end   
+            printf "--------------------------------------------------------------------"
+            if ($64BITS == 1)
+                printf "---------------------------------------------"
+            end
+            color $COLOR_SEPARATOR
+            color_bold
+            printf "[ObjectiveC]\n"
+            color_reset
+            color $BLACK
+            x/s $objectivec
+        end
     end
     color_reset
-# and this is the end of this little crap
+    # and this is the end of this little crap
 
     if $SHOWDATAWIN == 1
         datawin
@@ -2134,31 +2134,31 @@ define context
     color $COLOR_SEPARATOR
     printf "--------------------------------------------------------------------------"
     if ($64BITS == 1)
-	    printf "---------------------------------------------"
-	end
-	color $COLOR_SEPARATOR
-	color_bold
+        printf "---------------------------------------------"
+    end
+    color $COLOR_SEPARATOR
+    color_bold
     printf "[code]\n"
     color_reset
     set $context_i = $CONTEXTSIZE_CODE
     if ($context_i > 0)
-        if ($SETCOLOR1STLINE == 1)	
-	        color $GREEN
+        if ($SETCOLOR1STLINE == 1)
+            color $GREEN
             if ($ARM == 1)
                 #       | $cpsr.t (Thumb flag)
                 x/i (unsigned int)$pc | (($cpsr >> 5) & 1)
             else
-    	        x/i $pc
+                x/i $pc
             end
-	        color_reset
-	    else
+            color_reset
+        else
             if ($ARM == 1)
                 #       | $cpsr.t (Thumb flag)
-	              x/i (unsigned int)$pc | (($cpsr >> 5) & 1)
+                x/i (unsigned int)$pc | (($cpsr >> 5) & 1)
             else
                 x/i $pc
             end
-	    end
+        end
         set $context_i--
     end
     while ($context_i > 0)
@@ -2170,9 +2170,9 @@ define context
     printf "----------------------------------------"
     if ($64BITS == 1)
         printf "---------------------------------------------\n"
-	else
-	    printf "\n"
-	end
+    else
+        printf "\n"
+    end
     color_reset
 end
 document context
@@ -2304,73 +2304,73 @@ define stepoframework
         # bl and bx opcodes
         # bx Rn  => ARM bits 27-20: 0 0 0 1 0 0 1 0 , bits 7-4: 0 0 0 1 ; Thumb bits: 15-7: 0 1 0 0 0 1 1 1 0
         # blx Rn => ARM bits 27-20: 0 0 0 1 0 0 1 0 , bits 7-4: 0 0 1 1 ; Thumb bits: 15-7: 0 1 0 0 0 1 1 1 1
-        # bl # => ARM bits 27-24: 1 0 1 1 ; Thumb bits: 15-11: 1 1 1 1 0 
-        # blx # => ARM bits 31-25: 1 1 1 1 1 0 1 ; Thumb bits: 15-11: 1 1 1 1 0 
+        # bl # => ARM bits 27-24: 1 0 1 1 ; Thumb bits: 15-11: 1 1 1 1 0
+        # blx # => ARM bits 31-25: 1 1 1 1 1 0 1 ; Thumb bits: 15-11: 1 1 1 1 0
         set $_nextaddress = 0
 
         # ARM Mode
         if ($_t_flag == 0)
-        	set $_branchesint = *(unsigned int*)$pc
-        	set $_bit31 = ($_branchesint >> 0x1F) & 1
-        	set $_bit30 = ($_branchesint >> 0x1E) & 1
-        	set $_bit29 = ($_branchesint >> 0x1D) & 1
-        	set $_bit28 = ($_branchesint >> 0x1C) & 1
-        	set $_bit27 = ($_branchesint >> 0x1B) & 1
-        	set $_bit26 = ($_branchesint >> 0x1A) & 1
-        	set $_bit25 = ($_branchesint >> 0x19) & 1
-        	set $_bit24 = ($_branchesint >> 0x18) & 1
-        	set $_bit23 = ($_branchesint >> 0x17) & 1
-        	set $_bit22 = ($_branchesint >> 0x16) & 1
-        	set $_bit21 = ($_branchesint >> 0x15) & 1
-        	set $_bit20 = ($_branchesint >> 0x14) & 1
-        	set $_bit7 = ($_branchesint >> 0x7) & 1
-        	set $_bit6 = ($_branchesint >> 0x6) & 1
-        	set $_bit5 = ($_branchesint >> 0x5) & 1
-        	set $_bit4 = ($_branchesint >> 0x4) & 1
-	
-            #	set $_lastbyte = *(unsigned char *)($pc+3)
-            #	set $_bits2724 = $_lastbyte & 0x1
-            #	set $_bits3128 = $_lastbyte >> 4
-            #	if ($_bits3128 == 0xF)
-            #		set $_bits2724 = $_lastbyte & 0xA
-            #		set $_bits2724 = $_bits2724 >> 1
-            #	end
-            #	set $_previousbyte = *(unsigned char *)($pc+2)
-            #	set $_bits2320 = $_previousbyte >> 4
-            #	printf "bits2724: %x bits2320: %x\n", $_bits2724, $_bits2320
-	
-        	if ($_bit27 == 0 && $_bit26 == 0 && $_bit25 == 0 && $_bit24 == 1 && $_bit23 == 0 && $_bit22 == 0 && $_bit21 == 1 && $_bit20 == 0 && $_bit7 == 0 && $_bit6 == 0 && $_bit5 == 0 && $_bit4 == 1)
-		        printf "Found a bx Rn\n"
-        		set $_nextaddress = $pc+0x4
-        	end
-        	if ($_bit27 == 0 && $_bit26 == 0 && $_bit25 == 0 && $_bit24 == 1 && $_bit23 == 0 && $_bit22 == 0 && $_bit21 == 1 && $_bit20 == 0 && $_bit7 == 0 && $_bit6 == 0 && $_bit5 == 1 && $_bit4 == 1)
-		        printf "Found a blx Rn\n"
-        		set $_nextaddress = $pc+0x4
-        	end
-        	if ($_bit27 == 1 && $_bit26 == 0 && $_bit25 == 1 && $_bit24 == 1)
-		        printf "Found a bl #\n"
-        		set $_nextaddress = $pc+0x4
-        	end
-        	if ($_bit31 == 1 && $_bit30 == 1 && $_bit29 == 1 && $_bit28 == 1 && $_bit27 == 1 && $_bit26 == 0 && $_bit25 == 1)
-		        printf "Found a blx #\n"
-        		set $_nextaddress = $pc+0x4
-        	end
+            set $_branchesint = *(unsigned int*)$pc
+            set $_bit31 = ($_branchesint >> 0x1F) & 1
+            set $_bit30 = ($_branchesint >> 0x1E) & 1
+            set $_bit29 = ($_branchesint >> 0x1D) & 1
+            set $_bit28 = ($_branchesint >> 0x1C) & 1
+            set $_bit27 = ($_branchesint >> 0x1B) & 1
+            set $_bit26 = ($_branchesint >> 0x1A) & 1
+            set $_bit25 = ($_branchesint >> 0x19) & 1
+            set $_bit24 = ($_branchesint >> 0x18) & 1
+            set $_bit23 = ($_branchesint >> 0x17) & 1
+            set $_bit22 = ($_branchesint >> 0x16) & 1
+            set $_bit21 = ($_branchesint >> 0x15) & 1
+            set $_bit20 = ($_branchesint >> 0x14) & 1
+            set $_bit7 = ($_branchesint >> 0x7) & 1
+            set $_bit6 = ($_branchesint >> 0x6) & 1
+            set $_bit5 = ($_branchesint >> 0x5) & 1
+            set $_bit4 = ($_branchesint >> 0x4) & 1
+
+            #   set $_lastbyte = *(unsigned char *)($pc+3)
+            #   set $_bits2724 = $_lastbyte & 0x1
+            #   set $_bits3128 = $_lastbyte >> 4
+            #   if ($_bits3128 == 0xF)
+            #       set $_bits2724 = $_lastbyte & 0xA
+            #       set $_bits2724 = $_bits2724 >> 1
+            #   end
+            #   set $_previousbyte = *(unsigned char *)($pc+2)
+            #   set $_bits2320 = $_previousbyte >> 4
+            #   printf "bits2724: %x bits2320: %x\n", $_bits2724, $_bits2320
+
+            if ($_bit27 == 0 && $_bit26 == 0 && $_bit25 == 0 && $_bit24 == 1 && $_bit23 == 0 && $_bit22 == 0 && $_bit21 == 1 && $_bit20 == 0 && $_bit7 == 0 && $_bit6 == 0 && $_bit5 == 0 && $_bit4 == 1)
+                printf "Found a bx Rn\n"
+                set $_nextaddress = $pc+0x4
+            end
+            if ($_bit27 == 0 && $_bit26 == 0 && $_bit25 == 0 && $_bit24 == 1 && $_bit23 == 0 && $_bit22 == 0 && $_bit21 == 1 && $_bit20 == 0 && $_bit7 == 0 && $_bit6 == 0 && $_bit5 == 1 && $_bit4 == 1)
+                printf "Found a blx Rn\n"
+                set $_nextaddress = $pc+0x4
+            end
+            if ($_bit27 == 1 && $_bit26 == 0 && $_bit25 == 1 && $_bit24 == 1)
+                printf "Found a bl #\n"
+                set $_nextaddress = $pc+0x4
+            end
+            if ($_bit31 == 1 && $_bit30 == 1 && $_bit29 == 1 && $_bit28 == 1 && $_bit27 == 1 && $_bit26 == 0 && $_bit25 == 1)
+                printf "Found a blx #\n"
+                set $_nextaddress = $pc+0x4
+            end
         # Thumb Mode
         else
             # 32 bits instructions in Thumb are divided into two half words
-        	set $_hw1 = *(unsigned short*)($pc)
-        	set $_hw2 = *(unsigned short*)($pc+2)
-	
-        	# bl/blx (immediate)
-        	# hw1: bits 15-11: 1 1 1 1 0
-        	# hw2: bits 15-14: 1 1 ; BL bit 12: 1 ; BLX bit 12: 0
-        	if ( ($_hw1 >> 0xC) == 0xF && (($_hw1 >> 0xB) & 1) == 0)
-		        if ( ((($_hw2 >> 0xF) & 1) == 1) && ((($_hw2 >> 0xE) & 1) == 1) )
-        			set $_nextaddress = $pc+0x4
-		        end
-        	end
+            set $_hw1 = *(unsigned short*)($pc)
+            set $_hw2 = *(unsigned short*)($pc+2)
+
+            # bl/blx (immediate)
+            # hw1: bits 15-11: 1 1 1 1 0
+            # hw2: bits 15-14: 1 1 ; BL bit 12: 1 ; BLX bit 12: 0
+            if ( ($_hw1 >> 0xC) == 0xF && (($_hw1 >> 0xB) & 1) == 0)
+                if ( ((($_hw2 >> 0xF) & 1) == 1) && ((($_hw2 >> 0xE) & 1) == 1) )
+                    set $_nextaddress = $pc+0x4
+                end
+            end
         end
-        # if we have found a call to bypass we set a temporary breakpoint on next instruction and continue 
+        # if we have found a call to bypass we set a temporary breakpoint on next instruction and continue
         if ($_nextaddress != 0)
             tbreak *$_nextaddress
             continue
@@ -2404,10 +2404,10 @@ define stepoframework
                 end
                 # call *0x??(%ebp) (0xFF55??) || call *0x??(%esi) (0xFF56??) || call *0x??(%edi) (0xFF5F??) || call *0x??(%ebx)
                 # call *0x??(%edx) (0xFF52??) || call *0x??(%ecx) (0xFF51??) || call *0x??(%edi) (0xFF57??) || call *0x??(%eax) (0xFF50??)
-                if ($_byte2 == 0x55 || $_byte2 == 0x56 || $_byte2 == 0x5F || $_byte2 == 0x53 || $_byte2 == 0x52 || $_byte2 == 0x51 || $_byte2 == 0x57 || $_byte2 == 0x50) 
+                if ($_byte2 == 0x55 || $_byte2 == 0x56 || $_byte2 == 0x5F || $_byte2 == 0x53 || $_byte2 == 0x52 || $_byte2 == 0x51 || $_byte2 == 0x57 || $_byte2 == 0x50)
                     set $_nextaddress = $pc + 0x3
                 end
-                # call *0x????????(%ebx) (0xFF93????????) || 
+                # call *0x????????(%ebx) (0xFF93????????) ||
                 if ($_byte2 == 0x93 || $_byte2 == 0x94 || $_byte2 == 0x90 || $_byte2 == 0x92 || $_byte2 == 0x95 || $_byte2 == 0x15)
                     set $_nextaddress = $pc + 6
                 end
@@ -2425,7 +2425,7 @@ define stepoframework
                end
             end
         end
-        # if we have found a call to bypass we set a temporary breakpoint on next instruction and continue 
+        # if we have found a call to bypass we set a temporary breakpoint on next instruction and continue
         if ($_nextaddress != 0)
             if ($arg0 == 1)
                 thbreak *$_nextaddress
@@ -2466,18 +2466,18 @@ end
 
 # FIXME: ARM
 define skip
-	x/2i $pc
-	set $instruction_size = (int)($_ - $pc)
-	set $pc = $pc + $instruction_size
-	if ($SKIPEXECUTE == 1)
-		if ($SKIPSTEP == 1)
-			stepo
-		else
-			stepi
-		end
-	else
-		context
-	end
+    x/2i $pc
+    set $instruction_size = (int)($_ - $pc)
+    set $pc = $pc + $instruction_size
+    if ($SKIPEXECUTE == 1)
+        if ($SKIPSTEP == 1)
+            stepo
+        else
+            stepi
+        end
+    else
+        context
+    end
 end
 document skip
 Syntax: skip
@@ -2496,7 +2496,7 @@ end
 # negative/less than (N), bit 31 of CPSR
 define cfn
     if $ARM == 1
-    	set $tempflag = $cpsr->n
+        set $tempflag = $cpsr->n
         if ($tempflag & 1)
             set $cpsr->n = $tempflag&~0x1
         else
@@ -2513,7 +2513,7 @@ end
 define cfc
 # Carry/Borrow/Extend (C), bit 29
     if $ARM == 1
-	    set $tempflag = $cpsr->c
+        set $tempflag = $cpsr->c
         if ($tempflag & 1)
             set $cpsr->c = $tempflag&~0x1
         else
@@ -2560,9 +2560,9 @@ end
 
 
 define cfz
-# zero (Z), bit 30
+    # zero (Z), bit 30
     if $ARM == 1
- 	    set $tempflag = $cpsr->z
+        set $tempflag = $cpsr->z
         if ($tempflag & 1)
             set $cpsr->z = $tempflag&~0x1
         else
@@ -2652,7 +2652,7 @@ end
 # Overflow (V), bit 28
 define cfv
     if $ARM == 1
-    	set $tempflag = $cpsr->v
+        set $tempflag = $cpsr->v
         if ($tempflag & 1)
             set $cpsr->v = $tempflag&~0x1
         else
@@ -2676,7 +2676,7 @@ define nop
     if ($argc > 2 || $argc == 0)
         help nop
     end
-  
+
     if $ARM == 1
         if ($argc == 1)
             if ($cpsr->t &1)
@@ -2687,30 +2687,30 @@ define nop
                 set *(int *)$arg0 = 0xe1a00000
             end
         else
-        	set $addr = $arg0
-        	if ($cpsr->t & 1)
-    	    	# thumb
-			    while ($addr < $arg1)
-				    set *(short *)$addr = 0x46c0
-				    set $addr = $addr + 2
-		    	end
-	    	else
-		    	# arm
-		    	while ($addr < $arg1)
-			    	set *(int *)$addr = 0xe1a00000
-			    	set $addr = $addr + 4
-			    end
-		    end			
-        end 
+            set $addr = $arg0
+            if ($cpsr->t & 1)
+                # thumb
+                while ($addr < $arg1)
+                    set *(short *)$addr = 0x46c0
+                    set $addr = $addr + 2
+                end
+            else
+                # arm
+                while ($addr < $arg1)
+                    set *(int *)$addr = 0xe1a00000
+                    set $addr = $addr + 4
+                end
+            end
+        end
     else
         if ($argc == 1)
-    	    set *(unsigned char *)$arg0 = 0x90
+            set *(unsigned char *)$arg0 = 0x90
         else
-        	set $addr = $arg0
-    	    while ($addr < $arg1)
-	    	    set *(unsigned char *)$addr = 0x90
-	    	    set $addr = $addr + 1
-    	    end
+            set $addr = $arg0
+            while ($addr < $arg1)
+                set *(unsigned char *)$addr = 0x90
+                set $addr = $addr + 1
+            end
         end
     end
 end
@@ -2725,15 +2725,15 @@ define null
     if ( $argc >2 || $argc == 0)
         help null
     end
- 
+
     if ($argc == 1)
-	    set *(unsigned char *)$arg0 = 0
+        set *(unsigned char *)$arg0 = 0
     else
-	    set $addr = $arg0
-    	while ($addr < $arg1)
-	        set *(unsigned char *)$addr = 0
-		    set $addr = $addr +1
-	    end
+        set $addr = $arg0
+        while ($addr < $arg1)
+            set *(unsigned char *)$addr = 0
+            set $addr = $addr +1
+        end
     end
 end
 document null
@@ -2767,16 +2767,16 @@ end
 
 define rint3
     if $ARM == 1
-      	set *(unsigned int *)$ORIGINAL_INT3ADDRESS = $ORIGINAL_INT3
-	    set $pc = $ORIGINAL_INT3ADDRESS
+        set *(unsigned int *)$ORIGINAL_INT3ADDRESS = $ORIGINAL_INT3
+        set $pc = $ORIGINAL_INT3ADDRESS
     else
-    	set *(unsigned char *)$ORIGINAL_INT3ADDRESS = $ORIGINAL_INT3
-    	if ($64BITS == 1)
-        	set $rip = $ORIGINAL_INT3ADDRESS
-    	else
-    	    set $eip = $ORIGINAL_INT3ADDRESS
-    	end
-	end
+        set *(unsigned char *)$ORIGINAL_INT3ADDRESS = $ORIGINAL_INT3
+        if ($64BITS == 1)
+            set $rip = $ORIGINAL_INT3ADDRESS
+        else
+            set $eip = $ORIGINAL_INT3ADDRESS
+        end
+    end
 end
 document rint3
 Syntax: rint3
@@ -2891,11 +2891,11 @@ define get_insn_type
                 set $INSN_TYPE = 2
             end
         end
-        if ($_byte1 == 0xFF)        
+        if ($_byte1 == 0xFF)
             # opcode extension
             set $_byte2 = *(unsigned char *)($arg0 + 1)
             set $_opext = ($_byte2 & 0x38)
-            if ($_opext == 0x10 || $_opext == 0x18) 
+            if ($_opext == 0x10 || $_opext == 0x18)
                 # "call"
                 set $INSN_TYPE = 3
             end
@@ -2919,11 +2919,11 @@ define step_to_call
     set $_saved_ctx = $SHOW_CONTEXT
     set $SHOW_CONTEXT = 0
     set $SHOW_NEST_INSN = 0
- 
+
     set logging file /dev/null
     set logging redirect on
     set logging on
- 
+
     set $_cont = 1
     while ($_cont > 0)
         stepi
@@ -2941,11 +2941,11 @@ define step_to_call
 
     set $SHOW_CONTEXT = $_saved_ctx
     set $SHOW_NEST_INSN = 0
- 
+
     set logging file ~/gdb.txt
     set logging redirect off
     set logging on
- 
+
     printf "step_to_call command stopped at:\n  "
     x/i $pc
     printf "\n"
@@ -2969,7 +2969,7 @@ define trace_calls
     set $SHOW_NEST_INSN = 0
     set $_nest = 1
     set listsize 0
-  
+
     set logging overwrite on
     set logging file ~/gdb_trace_calls.txt
     set logging on
@@ -3011,7 +3011,7 @@ define trace_calls
 
     set $SHOW_CONTEXT = $_saved_ctx
     set $SHOW_NEST_INSN = 0
- 
+
     printf "Done, check ~/gdb_trace_calls.txt\n"
 end
 document trace_calls
@@ -3022,7 +3022,7 @@ end
 
 
 define trace_run
- 
+
     printf "Tracing...please wait...\n"
 
     set $_saved_ctx = $SHOW_CONTEXT
@@ -3069,17 +3069,17 @@ Syntax: trace_run
 end
 
 define entry_point
-	
-	set logging redirect on
-	set logging file /tmp/gdb-entry_point
-	set logging on
 
-	info files
+    set logging redirect on
+    set logging file /tmp/gdb-entry_point
+    set logging on
 
-	set logging off
+    info files
 
-	shell entry_point="$(/usr/bin/grep 'Entry point:' /tmp/gdb-entry_point | /usr/bin/awk '{ print $3 }')"; echo "$entry_point"; echo 'set $entry_point_address = '"$entry_point" > /tmp/gdb-entry_point
-	source /tmp/gdb-entry_point
+    set logging off
+
+    shell entry_point="$(/usr/bin/grep 'Entry point:' /tmp/gdb-entry_point | /usr/bin/awk '{ print $3 }')"; echo "$entry_point"; echo 'set $entry_point_address = '"$entry_point" > /tmp/gdb-entry_point
+    source /tmp/gdb-entry_point
     shell /bin/rm -f /tmp/gdb-entry_point
 end
 document entry_point
@@ -3088,8 +3088,8 @@ Syntax: entry_point
 end
 
 define break_entrypoint
-	entry_point
-	break *$entry_point_address
+    entry_point
+    break *$entry_point_address
 end
 document break_entrypoint
 Syntax: break_entrypoint
@@ -3098,19 +3098,19 @@ end
 
 define objc_symbols
 
-	set logging redirect on
-	set logging file /tmp/gdb-objc_symbols
-	set logging on
+    set logging redirect on
+    set logging file /tmp/gdb-objc_symbols
+    set logging on
 
-	info target
+    info target
 
-	set logging off
+    set logging off
     # XXX: define paths for objc-symbols and SymTabCreator
-	shell target="$(/usr/bin/head -1 /tmp/gdb-objc_symbols | /usr/bin/head -1 | /usr/bin/awk -F '"' '{ print $2 }')"; objc-symbols "$target" | SymTabCreator -o /tmp/gdb-symtab
+    shell target="$(/usr/bin/head -1 /tmp/gdb-objc_symbols | /usr/bin/head -1 | /usr/bin/awk -F '"' '{ print $2 }')"; objc-symbols "$target" | SymTabCreator -o /tmp/gdb-symtab
 
-	set logging on
-	add-symbol-file /tmp/gdb-symtab
-	set logging off
+    set logging on
+    add-symbol-file /tmp/gdb-symtab
+    set logging off
     shell /bin/rm -f /tmp/gdb-objc_symbols
 end
 document objc_symbols
@@ -3125,7 +3125,7 @@ end
 #    commands
 #        if ($64BITS == 0)
 #            if ($ebx == 0)
-#	        set $eax = 0
+#            set $eax = 0
 #                continue
 #            end
 #        else
@@ -3218,39 +3218,39 @@ define assemble
         printf "Instructions will be written to stdout.\n"
     end
     printf "Type instructions, one per line."
-	color_bold
+    color_bold
     printf " Do not forget to use NASM assembler syntax!\n"
     color_reset
     printf "End with a line saying just \"end\".\n"
-    
+
     if ($argc)
-	    if ($64BITS == 1)
-		    # argument specified, assemble instructions into memory at address specified.
-    		shell ASMOPCODE="$(while read -ep '>' r && test "$r" != end ; do echo -E "$r"; done)" ; GDBASMFILENAME=$RANDOM; \
-    		echo -e "BITS 64\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; /usr/local/bin/nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | /usr/bin/hexdump -ve '1/1 "set *((unsigned char *) $arg0 + %#2_ax) = %#02x\n"' >/tmp/gdbassemble ; /bin/rm -f /tmp/$GDBASMFILENAME
-    		source /tmp/gdbassemble
-    		# all done. clean the temporary file
-    		shell /bin/rm -f /tmp/gdbassemble
-    	else
-	    	# argument specified, assemble instructions into memory at address specified.
-	    	shell ASMOPCODE="$(while read -ep '>' r && test "$r" != end ; do echo -E "$r"; done)" ; GDBASMFILENAME=$RANDOM; \
-		    echo -e "BITS 32\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; /usr/bin/nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | /usr/bin/hexdump -ve '1/1 "set *((unsigned char *) $arg0 + %#2_ax) = %#02x\n"' >/tmp/gdbassemble ; /bin/rm -f /tmp/$GDBASMFILENAME
-    		source /tmp/gdbassemble
-	    	# all done. clean the temporary file
-		    shell /bin/rm -f /tmp/gdbassemble
-    	end
+        if ($64BITS == 1)
+            # argument specified, assemble instructions into memory at address specified.
+            shell ASMOPCODE="$(while read -ep '>' r && test "$r" != end ; do echo -E "$r"; done)" ; GDBASMFILENAME=$RANDOM; \
+            echo -e "BITS 64\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; /usr/local/bin/nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | /usr/bin/hexdump -ve '1/1 "set *((unsigned char *) $arg0 + %#2_ax) = %#02x\n"' >/tmp/gdbassemble ; /bin/rm -f /tmp/$GDBASMFILENAME
+            source /tmp/gdbassemble
+            # all done. clean the temporary file
+            shell /bin/rm -f /tmp/gdbassemble
+        else
+            # argument specified, assemble instructions into memory at address specified.
+            shell ASMOPCODE="$(while read -ep '>' r && test "$r" != end ; do echo -E "$r"; done)" ; GDBASMFILENAME=$RANDOM; \
+            echo -e "BITS 32\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; /usr/bin/nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | /usr/bin/hexdump -ve '1/1 "set *((unsigned char *) $arg0 + %#2_ax) = %#02x\n"' >/tmp/gdbassemble ; /bin/rm -f /tmp/$GDBASMFILENAME
+            source /tmp/gdbassemble
+            # all done. clean the temporary file
+            shell /bin/rm -f /tmp/gdbassemble
+        end
     else
-	    if ($64BITS == 1)
-		    # no argument, assemble instructions to stdout
-    		shell ASMOPCODE="$(while read -ep '>' r && test "$r" != end ; do echo -E "$r"; done)" ; GDBASMFILENAME=$RANDOM; \
-	    	echo -e "BITS 64\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; /usr/local/bin/nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | /usr/local/bin/ndisasm -i -b64 /dev/stdin ; \
-		    /bin/rm -f /tmp/$GDBASMFILENAME
-    	else
-	    	# no argument, assemble instructions to stdout
-	    	shell ASMOPCODE="$(while read -ep '>' r && test "$r" != end ; do echo -E "$r"; done)" ; GDBASMFILENAME=$RANDOM; \
-	    	echo -e "BITS 32\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; /usr/bin/nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | /usr/bin/ndisasm -i -b32 /dev/stdin ; \
-		    /bin/rm -f /tmp/$GDBASMFILENAME
-    	end
+        if ($64BITS == 1)
+            # no argument, assemble instructions to stdout
+            shell ASMOPCODE="$(while read -ep '>' r && test "$r" != end ; do echo -E "$r"; done)" ; GDBASMFILENAME=$RANDOM; \
+            echo -e "BITS 64\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; /usr/local/bin/nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | /usr/local/bin/ndisasm -i -b64 /dev/stdin ; \
+            /bin/rm -f /tmp/$GDBASMFILENAME
+        else
+            # no argument, assemble instructions to stdout
+            shell ASMOPCODE="$(while read -ep '>' r && test "$r" != end ; do echo -E "$r"; done)" ; GDBASMFILENAME=$RANDOM; \
+            echo -e "BITS 32\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; /usr/bin/nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | /usr/bin/ndisasm -i -b32 /dev/stdin ; \
+            /bin/rm -f /tmp/$GDBASMFILENAME
+        end
     end
 end
 document assemble
@@ -3279,7 +3279,7 @@ define assemble32
     printf " Do not forget to use NASM assembler syntax!\n"
     color_reset
     printf "End with a line saying just \"end\".\n"
-    
+
     if ($argc)
         # argument specified, assemble instructions into memory at address specified.
         shell ASMOPCODE="$(while read -ep '>' r && test "$r" != end ; do echo -E "$r"; done)" ; GDBASMFILENAME=$RANDOM; \
@@ -3320,7 +3320,7 @@ define assemble64
     printf " Do not forget to use NASM assembler syntax!\n"
     color_reset
     printf "End with a line saying just \"end\".\n"
-    
+
     if ($argc)
         # argument specified, assemble instructions into memory at address specified.
         shell ASMOPCODE="$(while read -ep '>' r && test "$r" != end ; do echo -E "$r"; done)" ; GDBASMFILENAME=$RANDOM; \
@@ -3345,11 +3345,11 @@ Syntax: assemble64 <ADDR>
 end
 
 define asm
-	if $argc == 1
-		assemble $arg0
-	else
-		assemble
-	end
+    if $argc == 1
+        assemble $arg0
+    else
+        assemble
+    end
 end
 document asm
 Syntax: asm <ADDR>
@@ -3538,7 +3538,7 @@ end
 define tip_syntax
     printf "\n"
     printf "\t    INTEL SYNTAX                        AT&T SYNTAX\n"
-    printf "\tmnemonic dest, src, imm            mnemonic src, dest, imm\n" 
+    printf "\tmnemonic dest, src, imm            mnemonic src, dest, imm\n"
     printf "\t[base+index*scale+disp]            disp(base, index, scale)\n"
     printf "\tregister:      eax                 register:      %%eax\n"
     printf "\timmediate:     0xFF                immediate:     $0xFF\n"
@@ -3584,8 +3584,8 @@ end
 
 # enable and disable shortcuts for stop-on-solib-events fantastic trick!
 define enablesolib
-	set stop-on-solib-events 1
-	printf "Stop-on-solib-events is enabled!\n"
+    set stop-on-solib-events 1
+    printf "Stop-on-solib-events is enabled!\n"
 end
 document enablesolib
 Syntax: enablesolib
@@ -3594,8 +3594,8 @@ end
 
 
 define disablesolib
-	set stop-on-solib-events 0
-	printf "Stop-on-solib-events is disabled!\n"
+    set stop-on-solib-events 0
+    printf "Stop-on-solib-events is disabled!\n"
 end
 document disablesolib
 Syntax: disablesolib
@@ -3605,7 +3605,7 @@ end
 
 # enable commands for different displays
 define enableobjectivec
-	set $SHOWOBJECTIVEC = 1
+    set $SHOWOBJECTIVEC = 1
 end
 document enableobjectivec
 Syntax: enableobjectivec
@@ -3614,7 +3614,7 @@ end
 
 
 define enablecpuregisters
-	set $SHOWCPUREGISTERS = 1
+    set $SHOWCPUREGISTERS = 1
 end
 document enablecpuregisters
 Syntax: enablecpuregisters
@@ -3623,7 +3623,7 @@ end
 
 
 define enablestack
-	set $SHOWSTACK = 1
+    set $SHOWSTACK = 1
 end
 document enablestack
 Syntax: enablestack
@@ -3632,7 +3632,7 @@ end
 
 
 define enabledatawin
-	set $SHOWDATAWIN = 1
+    set $SHOWDATAWIN = 1
 end
 document enabledatawin
 Syntax: enabledatawin
@@ -3642,7 +3642,7 @@ end
 
 # disable commands for different displays
 define disableobjectivec
-	set $SHOWOBJECTIVEC = 0
+    set $SHOWOBJECTIVEC = 0
 end
 document disableobjectivec
 Syntax: disableobjectivec
@@ -3651,7 +3651,7 @@ end
 
 
 define disablecpuregisters
-	set $SHOWCPUREGISTERS = 0
+    set $SHOWCPUREGISTERS = 0
 end
 document disablecpuregisters
 Syntax: disablecpuregisters
@@ -3660,7 +3660,7 @@ end
 
 
 define disablestack
-	set $SHOWSTACK = 0
+    set $SHOWSTACK = 0
 end
 document disablestack
 Syntax: disablestack
@@ -3669,7 +3669,7 @@ end
 
 
 define disabledatawin
-	set $SHOWDATAWIN = 0
+    set $SHOWDATAWIN = 0
 end
 document disabledatawin
 Syntax: disabledatawin
@@ -3836,24 +3836,24 @@ end
 #     - Added the "skip" command. This will jump to the next instruction after EIP/RIP without executing the current one.
 #       Thanks to @bSr43 for the tip to retrieve the current instruction size.
 #
-#	Version 7.4.3 (04/11/2011)
-#	  - Modified "hexdump" command to support a variable number of lines (optional parameter)
-#	  - Removed restrictions on type of addresses in the "dd" command - Thanks to Plouj for the warning :-)
-#	   I don't know what was the original thinking behind those :-)
-#	  - Modified the assemble command to support 64bits - You will need to recompile nasm since the version shipped with OS X doesn't supports 64bits (www.nasm.us).
-#	   Assumes that the new binary is installed at /usr/local/bin - modify the variable at the top if you need so. 
-#	   It will assemble based on the target arch being debugged. If you want to use gdb for a quick asm just use the 32bits or 64bits commands to set your target.
+#   Version 7.4.3 (04/11/2011)
+#     - Modified "hexdump" command to support a variable number of lines (optional parameter)
+#     - Removed restrictions on type of addresses in the "dd" command - Thanks to Plouj for the warning :-)
+#      I don't know what was the original thinking behind those :-)
+#     - Modified the assemble command to support 64bits - You will need to recompile nasm since the version shipped with OS X doesn't supports 64bits (www.nasm.us).
+#      Assumes that the new binary is installed at /usr/local/bin - modify the variable at the top if you need so.
+#      It will assemble based on the target arch being debugged. If you want to use gdb for a quick asm just use the 32bits or 64bits commands to set your target.
 #      Thanks to snare for the warning and original patch :-)
-#	  - Added "asm" command - it's a shortcut to the "assemble" command.
-#	  - Added configuration variable for colorized prompt. Plouj reported some issues with Ubuntu's gdb 7.2 if prompt is colorized.
+#     - Added "asm" command - it's a shortcut to the "assemble" command.
+#     - Added configuration variable for colorized prompt. Plouj reported some issues with Ubuntu's gdb 7.2 if prompt is colorized.
 #
 #   Version 7.4.2 (11/08/2011)
 #    Small fix to a weird bug happening on FreeBSD 8.2. It doesn't like a "if(" instruction, needs to be "if (". Weird!
 #     Many thanks to Evan for reporting and sending the patch :-)
 #    Added the ptraceme/rptraceme commands to bypass PTRACE_TRACME anti-debugging technique.
 #     Grabbed this from http://falken.tuxfamily.org/?p=171
-#	  It's commented out due to a gdb problem in OS X (refer to http://reverse.put.as/2011/08/20/another-patch-for-apples-gdb-the-definecommands-problem/ )
-#	  Just uncomment it if you want to use in ptrace enabled systems.
+#     It's commented out due to a gdb problem in OS X (refer to http://reverse.put.as/2011/08/20/another-patch-for-apples-gdb-the-definecommands-problem/ )
+#     Just uncomment it if you want to use in ptrace enabled systems.
 #
 #   Version 7.4.1 (21/06/2011) - fG!
 #    Added patch sent by sbz, more than 1 year ago, which I forgot to add :-/
@@ -3867,25 +3867,25 @@ end
 #    Added patch sent by Philippe Langlois
 #     color the first disassembly line - change the setting below on SETCOLOR1STLINE - by default it's disabled
 #
-#	Version 7.3.2 (21/02/2011) - fG!
-#	  Added the command rint3 and modified the int3 command. The new command will restore the byte in previous int3 patch.
+#   Version 7.3.2 (21/02/2011) - fG!
+#     Added the command rint3 and modified the int3 command. The new command will restore the byte in previous int3 patch.
 #
-# 	Version 7.3.1 (29/06/2010) - fG!
-#	  Added enablelib/disablelib command to quickly set the stop-on-solib-events trick
-#	  Implemented the stepoh command equivalent to the stepo but using hardware breakpoints 
-#	  More fixes to stepo
+#   Version 7.3.1 (29/06/2010) - fG!
+#     Added enablelib/disablelib command to quickly set the stop-on-solib-events trick
+#     Implemented the stepoh command equivalent to the stepo but using hardware breakpoints
+#     More fixes to stepo
 #
-#	Version 7.3 (16/04/2010) - fG!
-#	  Support for 64bits targets. Default is 32bits, you should modify the variable or use the 32bits or 64bits to choose the mode.
-#     	  I couldn't find another way to recognize the type of binary… Testing the register doesn't work that well.
-#	  TODO: fix objectivec messages and stepo for 64bits
+#   Version 7.3 (16/04/2010) - fG!
+#     Support for 64bits targets. Default is 32bits, you should modify the variable or use the 32bits or 64bits to choose the mode.
+#         I couldn't find another way to recognize the type of binary… Testing the register doesn't work that well.
+#     TODO: fix objectivec messages and stepo for 64bits
 #   Version 7.2.1 (24/11/2009) - fG!
-#	  Another fix to stepo (0xFF92 missing)
+#     Another fix to stepo (0xFF92 missing)
 #
 #   Version 7.2 (11/10/2009) - fG!
-#	  Added the smallregisters function to create 16 and 8 bit versions from the registers EAX, EBX, ECX, EDX
-#	  Revised and fixed all the dumpjump stuff, following Intel manuals. There were some errors (thx to rev who pointed the jle problem).
-#	  Small fix to stepo command (missed a few call types)
+#     Added the smallregisters function to create 16 and 8 bit versions from the registers EAX, EBX, ECX, EDX
+#     Revised and fixed all the dumpjump stuff, following Intel manuals. There were some errors (thx to rev who pointed the jle problem).
+#     Small fix to stepo command (missed a few call types)
 #
 #   Version 7.1.7 - fG!
 #     Added the possibility to modify what's displayed with the context window. You can change default options at the gdb options part. For example, kernel debugging is much slower if the stack display is enabled...
@@ -3965,7 +3965,7 @@ end
 #     Add global variables to allow user to control stack, data and code window sizes
 #     Increase readability for registers
 #     Some corrections (hexdump, ddump, context, cfp, assemble, gas_asm, tips, prompt)
-#   
+#
 #   Version 6.1-color-user
 #     Took the Gentoo route and ran sed s/user/user/g
 #

--- a/gdbinit
+++ b/gdbinit
@@ -3078,9 +3078,9 @@ define entry_point
 
     set logging off
 
-    shell entry_point="$(/usr/bin/grep 'Entry point:' /tmp/gdb-entry_point | /usr/bin/awk '{ print $3 }')"; echo "$entry_point"; echo 'set $entry_point_address = '"$entry_point" > /tmp/gdb-entry_point
+    shell entry_point="$(grep 'Entry point:' /tmp/gdb-entry_point | awk '{ print $3 }')"; echo "$entry_point"; echo 'set $entry_point_address = '"$entry_point" > /tmp/gdb-entry_point
     source /tmp/gdb-entry_point
-    shell /bin/rm -f /tmp/gdb-entry_point
+    shell rm -f /tmp/gdb-entry_point
 end
 document entry_point
 Syntax: entry_point
@@ -3106,12 +3106,12 @@ define objc_symbols
 
     set logging off
     # XXX: define paths for objc-symbols and SymTabCreator
-    shell target="$(/usr/bin/head -1 /tmp/gdb-objc_symbols | /usr/bin/head -1 | /usr/bin/awk -F '"' '{ print $2 }')"; objc-symbols "$target" | SymTabCreator -o /tmp/gdb-symtab
+    shell target=$(head -1 /tmp/gdb-objc_symbols | awk -F '"' '{print $2}'); objc-symbols "$target" | SymTabCreator -o /tmp/gdb-symtab
 
     set logging on
     add-symbol-file /tmp/gdb-symtab
     set logging off
-    shell /bin/rm -f /tmp/gdb-objc_symbols
+    shell rm -f /tmp/gdb-objc_symbols
 end
 document objc_symbols
 Syntax: objc_symbols
@@ -3227,29 +3227,29 @@ define assemble
         if ($64BITS == 1)
             # argument specified, assemble instructions into memory at address specified.
             shell ASMOPCODE="$(while read -ep '>' r && test "$r" != end ; do echo -E "$r"; done)" ; GDBASMFILENAME=$RANDOM; \
-            echo -e "BITS 64\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; /usr/local/bin/nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | /usr/bin/hexdump -ve '1/1 "set *((unsigned char *) $arg0 + %#2_ax) = %#02x\n"' >/tmp/gdbassemble ; /bin/rm -f /tmp/$GDBASMFILENAME
+                echo -e "BITS 64\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | hexdump -ve '1/1 "set *((unsigned char *) $arg0 + %#2_ax) = %#02x\n"' >/tmp/gdbassemble ; rm -f /tmp/$GDBASMFILENAME
             source /tmp/gdbassemble
             # all done. clean the temporary file
-            shell /bin/rm -f /tmp/gdbassemble
+            shell rm -f /tmp/gdbassemble
         else
             # argument specified, assemble instructions into memory at address specified.
             shell ASMOPCODE="$(while read -ep '>' r && test "$r" != end ; do echo -E "$r"; done)" ; GDBASMFILENAME=$RANDOM; \
-            echo -e "BITS 32\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; /usr/bin/nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | /usr/bin/hexdump -ve '1/1 "set *((unsigned char *) $arg0 + %#2_ax) = %#02x\n"' >/tmp/gdbassemble ; /bin/rm -f /tmp/$GDBASMFILENAME
+                echo -e "BITS 32\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | hexdump -ve '1/1 "set *((unsigned char *) $arg0 + %#2_ax) = %#02x\n"' >/tmp/gdbassemble ; rm -f /tmp/$GDBASMFILENAME
             source /tmp/gdbassemble
             # all done. clean the temporary file
-            shell /bin/rm -f /tmp/gdbassemble
+            shell rm -f /tmp/gdbassemble
         end
     else
         if ($64BITS == 1)
             # no argument, assemble instructions to stdout
             shell ASMOPCODE="$(while read -ep '>' r && test "$r" != end ; do echo -E "$r"; done)" ; GDBASMFILENAME=$RANDOM; \
-            echo -e "BITS 64\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; /usr/local/bin/nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | /usr/local/bin/ndisasm -i -b64 /dev/stdin ; \
-            /bin/rm -f /tmp/$GDBASMFILENAME
+                echo -e "BITS 64\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | ndisasm -i -b64 /dev/stdin ; \
+            rm -f /tmp/$GDBASMFILENAME
         else
             # no argument, assemble instructions to stdout
             shell ASMOPCODE="$(while read -ep '>' r && test "$r" != end ; do echo -E "$r"; done)" ; GDBASMFILENAME=$RANDOM; \
-            echo -e "BITS 32\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; /usr/bin/nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | /usr/bin/ndisasm -i -b32 /dev/stdin ; \
-            /bin/rm -f /tmp/$GDBASMFILENAME
+                echo -e "BITS 32\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | ndisasm -i -b32 /dev/stdin ; \
+            rm -f /tmp/$GDBASMFILENAME
         end
     end
 end
@@ -3283,15 +3283,15 @@ define assemble32
     if ($argc)
         # argument specified, assemble instructions into memory at address specified.
         shell ASMOPCODE="$(while read -ep '>' r && test "$r" != end ; do echo -E "$r"; done)" ; GDBASMFILENAME=$RANDOM; \
-        echo -e "BITS 32\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; /usr/bin/nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | /usr/bin/hexdump -ve '1/1 "set *((unsigned char *) $arg0 + %#2_ax) = %#02x\n"' >/tmp/gdbassemble ; /bin/rm -f /tmp/$GDBASMFILENAME
+            echo -e "BITS 32\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | hexdump -ve '1/1 "set *((unsigned char *) $arg0 + %#2_ax) = %#02x\n"' >/tmp/gdbassemble ; rm -f /tmp/$GDBASMFILENAME
         source /tmp/gdbassemble
         # all done. clean the temporary file
-        shell /bin/rm -f /tmp/gdbassemble
+        shell rm -f /tmp/gdbassemble
     else
         # no argument, assemble instructions to stdout
         shell ASMOPCODE="$(while read -ep '>' r && test "$r" != end ; do echo -E "$r"; done)" ; GDBASMFILENAME=$RANDOM; \
-        echo -e "BITS 32\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; /usr/bin/nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | /usr/bin/ndisasm -i -b32 /dev/stdin ; \
-        /bin/rm -f /tmp/$GDBASMFILENAME
+            echo -e "BITS 32\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | ndisasm -i -b32 /dev/stdin ; \
+        rm -f /tmp/$GDBASMFILENAME
     end
 end
 document assemble32
@@ -3324,15 +3324,15 @@ define assemble64
     if ($argc)
         # argument specified, assemble instructions into memory at address specified.
         shell ASMOPCODE="$(while read -ep '>' r && test "$r" != end ; do echo -E "$r"; done)" ; GDBASMFILENAME=$RANDOM; \
-        echo -e "BITS 64\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; /usr/local/bin/nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | /usr/bin/hexdump -ve '1/1 "set *((unsigned char *) $arg0 + %#2_ax) = %#02x\n"' >/tmp/gdbassemble ; /bin/rm -f /tmp/$GDBASMFILENAME
+           echo -e "BITS 64\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | hexdump -ve '1/1 "set *((unsigned char *) $arg0 + %#2_ax) = %#02x\n"' >/tmp/gdbassemble ; rm -f /tmp/$GDBASMFILENAME
         source /tmp/gdbassemble
         # all done. clean the temporary file
-        shell /bin/rm -f /tmp/gdbassemble
+        shell rm -f /tmp/gdbassemble
     else
         # no argument, assemble instructions to stdout
         shell ASMOPCODE="$(while read -ep '>' r && test "$r" != end ; do echo -E "$r"; done)" ; GDBASMFILENAME=$RANDOM; \
-        echo -e "BITS 64\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; /usr/local/bin/nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | /usr/local/bin/ndisasm -i -b64 /dev/stdin ; \
-        /bin/rm -f /tmp/$GDBASMFILENAME
+            echo -e "BITS 64\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | ndisasm -i -b64 /dev/stdin ; \
+        rm -f /tmp/$GDBASMFILENAME
     end
 end
 document assemble64
@@ -3789,8 +3789,8 @@ define header
         help header
     else
         dump memory /tmp/gdbinit_header_dump $arg0 $arg0 + 4096
-        shell /usr/bin/otool -h /tmp/gdbinit_header_dump
-        shell /bin/rm -f /tmp/gdbinit_header_dump
+        shell otool -h /tmp/gdbinit_header_dump
+        shell rm -f /tmp/gdbinit_header_dump
     end
 end
 document header
@@ -3804,8 +3804,8 @@ define loadcmds
     else
         # this size should be good enough for most binaries
         dump memory /tmp/gdbinit_header_dump $arg0 $arg0 + 4096 * 10
-        shell /usr/bin/otool -l /tmp/gdbinit_header_dump
-        shell /bin/rm -f /tmp/gdbinit_header_dump
+        shell otool -l /tmp/gdbinit_header_dump
+        shell rm -f /tmp/gdbinit_header_dump
     end
 end
 document loadcmds


### PR DESCRIPTION
Relying on full paths is a bad idea, e.g. grep is not always at /usr/bin/grep, sometimes it's just /bin/grep. Same for awk. There are even inconsistencies: one time it's /usr/local/bin/nasm, another time /usr/bin/nasm.
I believe it would be better without full path and instead rely on $PATH to find binaries, as it is normal practice on unix systems.
