### PR TITLE
do not "set arm show-opcode-bytes" when not necessary

### DIFF
--- a/gdbinit
+++ b/gdbinit
@@ -3157,8 +3157,6 @@ define hook-stop
     if $ARM == 1
         if $ARMOPCODES == 1
             set arm show-opcode-bytes 1
-        else
-            set arm show-opcode-bytes 0
         end
     else
         if $X86FLAVOR == 0
@@ -3665,8 +3663,6 @@ end
 define arm
     if $ARMOPCODES == 1
         set arm show-opcode-bytes 1
-    else
-       set arm show-opcode-bytes 1
     end
     set $ARM = 1
 end


### PR DESCRIPTION
On the ARMv7 boxes of http://ioarm.smashthestack.org/  "set arm show-opcode-bytes" is an undefined command, therefore when called in hook-stop it breaks hard and context cannot be displayed properly.

$ uname -a
Linux arm1 3.8.13.13-30068-g2296bce #12 SMP PREEMPT Mon Feb 3 15:50:09 CET 2014 armv7l armv7l armv7l GNU/Linux
$ gdb
GNU gdb (GDB) 7.5.91.20130417-cvs-ubuntu
This GDB was configured as "arm-linux-gnueabihf".
(gdb) set arm show-opcode-bytes 0
Undefined set arm command: "show-opcode-bytes 0".  Try "help set arm".

It would be nice if we could test if the command exists before using it but I don't know a way.
In the meantime I suggest to simply not set it when $ARMOPCODES is not 1.
As a result hook-stop doesn't break and context works.
