### PR TITLE
Add color support for latest gdb version

### DIFF
--- a/gdbinit
+++ b/gdbinit
@@ -104,6 +104,7 @@ set $64BITS = 0
 
 set confirm off
 set verbose off
+set style enabled off
 set history filename ~/.gdb_history
 set history save
 


### PR DESCRIPTION
![before change](https://user-images.githubusercontent.com/22578848/137854889-2220b576-5c56-40e7-a645-16acb886a493.png)
GDB added its own color styling, which is incompatible with the color settings in .gdbinit, so we need to manually disable it to get the color settings to work.
![after change](https://user-images.githubusercontent.com/22578848/137854876-7e6fb6ec-e2b3-4384-b508-7064c7a98680.png)
