### PR TITLE
Whitespace fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,7 @@
      - Other fixes and additions from previous commits
 
    Version 8.0.4 (08/05/2013)
-     - Detect automatically 32 or 64 bits archs using sizeof(void*). 
+     - Detect automatically 32 or 64 bits archs using sizeof(void*).
        Thanks to Tyilo for the simple but very effective idea!
      - Typo in hexdump command also fixed by vuquangtrong.
      - Add shortcuts to attach to VMware kernel debugging gdb stub (kernel32 and kernel64)
@@ -41,7 +41,7 @@
     - Removed restrictions on type of addresses in the "dd" command - Thanks to Plouj for the warning :-)
      I don't know what was the original thinking behind those :-)
     - Modified the assemble command to support 64bits - You will need to recompile nasm since the version shipped with OS X doesn't supports 64bits (www.nasm.us).
-     Assumes that the new binary is installed at /usr/local/bin - modify the variable at the top if you need so. 
+     Assumes that the new binary is installed at /usr/local/bin - modify the variable at the top if you need so.
      It will assemble based on the target arch being debugged. If you want to use gdb for a quick asm just use the 32bits or 64bits commands to set your target.
        Thanks to snare for the warning and original patch :-)
     - Added "asm" command - it's a shortcut to the "assemble" command.
@@ -72,7 +72,7 @@
 
    Version 7.3.1 (29/06/2010) - fG!
      Added enablelib/disablelib command to quickly set the stop-on-solib-events trick
-     Implemented the stepoh command equivalent to the stepo but using hardware breakpoints 
+     Implemented the stepoh command equivalent to the stepo but using hardware breakpoints
      More fixes to stepo
 
    Version 7.3 (16/04/2010) - fG!
@@ -165,7 +165,7 @@
      Add global variables to allow user to control stack, data and code window sizes
      Increase readability for registers
      Some corrections (hexdump, ddump, context, cfp, assemble, gas_asm, tips, prompt)
-   
+
    Version 6.1-color-user
      Took the Gentoo route and ran sed s/user/user/g
 

--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ FEEDBACK: https://reverse.put.as - reverser@put.as
 
 You should read the header of the script for important information regarding some Mac OS X/iOS gdb bugs.
 
-Have fun,  
+Have fun,
 fG!

--- a/gdbinit
+++ b/gdbinit
@@ -2318,16 +2318,16 @@ define stepoframework
             set $_bit5 = ($_branchesint >> 0x5) & 1
             set $_bit4 = ($_branchesint >> 0x4) & 1
 
-            #	set $_lastbyte = *(unsigned char *)($pc+3)
-            #	set $_bits2724 = $_lastbyte & 0x1
-            #	set $_bits3128 = $_lastbyte >> 4
-            #	if ($_bits3128 == 0xF)
-            #		set $_bits2724 = $_lastbyte & 0xA
-            #		set $_bits2724 = $_bits2724 >> 1
-            #	end
-            #	set $_previousbyte = *(unsigned char *)($pc+2)
-            #	set $_bits2320 = $_previousbyte >> 4
-            #	printf "bits2724: %x bits2320: %x\n", $_bits2724, $_bits2320
+            # set $_lastbyte = *(unsigned char *)($pc+3)
+            # set $_bits2724 = $_lastbyte & 0x1
+            # set $_bits3128 = $_lastbyte >> 4
+            # if ($_bits3128 == 0xF)
+            #     set $_bits2724 = $_lastbyte & 0xA
+            #     set $_bits2724 = $_bits2724 >> 1
+            # end
+            # set $_previousbyte = *(unsigned char *)($pc+2)
+            # set $_bits2320 = $_previousbyte >> 4
+            # printf "bits2724: %x bits2320: %x\n", $_bits2724, $_bits2320
 
             if ($_bit27 == 0 && $_bit26 == 0 && $_bit25 == 0 && $_bit24 == 1 && $_bit23 == 0 && $_bit22 == 0 && $_bit21 == 1 && $_bit20 == 0 && $_bit7 == 0 && $_bit6 == 0 && $_bit5 == 0 && $_bit4 == 1)
                 printf "Found a bx Rn\n"

--- a/gdbinit
+++ b/gdbinit
@@ -315,7 +315,7 @@ Syntax: bp LOCATION
 end
 
 
-define bpc 
+define bpc
     if $argc != 1
         help bpc
     else
@@ -488,7 +488,7 @@ define flagsarm
         printf "v "
         set $_v_flag = 0
     end
-    # Sticky overflow (Q), bit 27    
+    # Sticky overflow (Q), bit 27
     if (($cpsr >> 0x1b) & 1)
         printf "Q "
         set $_q_flag = 1
@@ -516,7 +516,7 @@ define flagsarm
         set $_e_flag = 0
     end
     # Imprecise abort disable bit (A), bit 8
-    # The A bit is set to 1 automatically. It is used to disable imprecise data aborts. 
+    # The A bit is set to 1 automatically. It is used to disable imprecise data aborts.
     # It might not be writable in the Nonsecure state if the AW bit in the SCR register is reset.
     if (($cpsr >> 8) & 1)
         printf "A "
@@ -535,7 +535,7 @@ define flagsarm
         set $_i_flag = 0
     end
     # FIQ disable bit (F), bit 6
-    # When the F bit is set to 1, FIQ interrupts are disabled. 
+    # When the F bit is set to 1, FIQ interrupts are disabled.
     # FIQ can be nonmaskable in the Nonsecure state if the FW bit in SCR register is reset.
     if (($cpsr >> 6) & 1)
         printf "F "
@@ -1052,8 +1052,8 @@ define regx86
     # EBX
     color $COLOR_REGNAME
     printf "EBX:"
-    if ($ebx != $oldebx && $SHOWREGCHANGES == 1) 
-        color $COLOR_REGVAL_MODIFIED		
+    if ($ebx != $oldebx && $SHOWREGCHANGES == 1)
+        color $COLOR_REGVAL_MODIFIED
     else
         color $COLOR_REGVAL
     end
@@ -1253,7 +1253,7 @@ define smallregisters
         set $si  = $rsi & 0xffff
         # from rdi
         set $edi = $rdi & 0xffffffff
-        set $di  = $rdi & 0xffff		
+        set $di  = $rdi & 0xffff
     #32 bits stuff
     else
         # from eax
@@ -1275,7 +1275,7 @@ define smallregisters
         # from esi
         set $si = $esi & 0xffff
         # from edi
-        set $di = $edi & 0xffff		
+        set $di = $edi & 0xffff
      end
 end
 document smallregisters
@@ -1364,7 +1364,7 @@ define dis
     end
     if $argc == 2
         disassemble $arg0 $arg1
-    end 
+    end
     if $argc > 2
         help dis
     end
@@ -1372,7 +1372,7 @@ end
 document dis
 Syntax: dis <ADDR1> <ADDR2>
 | Disassemble a specified section of memory.
-| Default is to disassemble the function surrounding the PC (program counter) of selected frame. 
+| Default is to disassemble the function surrounding the PC (program counter) of selected frame.
 | With one argument, ADDR1, the function surrounding this address is dumped.
 | Two arguments are taken as a range of memory to dump.
 end
@@ -1435,7 +1435,7 @@ end
 document hexdump
 Syntax: hexdump ADDR <NR_LINES>
 | Display a 16-byte hex/ASCII dump of memory starting at address ADDR.
-| Optional parameter is the number of lines to display if you want more than one. 
+| Optional parameter is the number of lines to display if you want more than one.
 end
 
 
@@ -1631,7 +1631,7 @@ define dumpjump
                 set $_conditional = *(unsigned char *)($pc+1) ^ 0xD0
                 dumpjumphelper
             end
-        end 
+        end
 ##################### X86
     else
         ## grab the first two bytes from the instruction so we can determine the jump instruction
@@ -1651,7 +1651,7 @@ define dumpjump
                 # cf != 0 or zf != 0
                 color $RED
                 printf "  Jump is NOT taken (c!=0 or z!=0)"
-            end 
+            end
         end
         ## opcode 0x73: JAE, JNB, JNC (jump if CF=0)
         ## opcode 0x0F83: JNC, JNB, JAE (jump if CF=0)
@@ -1664,7 +1664,7 @@ define dumpjump
                 # cf != 0
                 color $RED
                 printf "  Jump is NOT taken (c!=0)"
-            end 
+            end
         end
         ## opcode 0x72: JB, JC, JNAE (jump if CF=1)
         ## opcode 0x0F82: JNAE, JB, JC
@@ -1677,7 +1677,7 @@ define dumpjump
                 # cf != 1
                 color $RED
                 printf "  Jump is NOT taken (c!=1)"
-            end 
+            end
         end
         ## opcode 0x76: JBE, JNA (jump if CF=1 or ZF=1)
         ## opcode 0x0F86: JBE, JNA
@@ -1690,7 +1690,7 @@ define dumpjump
                 # cf != 1 or zf != 1
                 color $RED
                 printf "  Jump is NOT taken (c!=1 or z!=1)"
-            end 
+            end
         end
         ## opcode 0xE3: JCXZ, JECXZ, JRCXZ (jump if CX=0 or ECX=0 or RCX=0)
         if ($_byte1 == 0xE3)
@@ -1701,7 +1701,7 @@ define dumpjump
             else
                 color $RED
                 printf "  Jump is NOT taken (cx!=0 or ecx!=0)"
-            end 
+            end
         end
         ## opcode 0x74: JE, JZ (jump if ZF=1)
         ## opcode 0x0F84: JZ, JE, JZ (jump if ZF=1)
@@ -1714,7 +1714,7 @@ define dumpjump
                 # ZF = 0
                 color $RED
                 printf "  Jump is NOT taken (z!=1)"
-            end 
+            end
         end
         ## opcode 0x7F: JG, JNLE (jump if ZF=0 and SF=OF)
         ## opcode 0x0F8F: JNLE, JG (jump if ZF=0 and SF=OF)
@@ -1726,7 +1726,7 @@ define dumpjump
             else
                 color $RED
                 printf "  Jump is NOT taken (z!=0 or s!=o)"
-            end 
+            end
         end
         ## opcode 0x7D: JGE, JNL (jump if SF=OF)
         ## opcode 0x0F8D: JNL, JGE (jump if SF=OF)
@@ -1738,7 +1738,7 @@ define dumpjump
             else
                 color $RED
                 printf "  Jump is NOT taken (s!=o)"
-            end 
+            end
         end
         ## opcode: 0x7C: JL, JNGE (jump if SF != OF)
         ## opcode: 0x0F8C: JNGE, JL (jump if SF != OF)
@@ -1750,7 +1750,7 @@ define dumpjump
             else
                 color $RED
                 printf "  Jump is NOT taken (s=o)"
-            end 
+            end
         end
         ## opcode 0x7E: JLE, JNG (jump if ZF = 1 or SF != OF)
         ## opcode 0x0F8E: JNG, JLE (jump if ZF = 1 or SF != OF)
@@ -1762,7 +1762,7 @@ define dumpjump
             else
                 color $RED
                 printf "  Jump is NOT taken (zf!=1 or sf=of)"
-            end 
+            end
         end
         ## opcode 0x75: JNE, JNZ (jump if ZF = 0)
         ## opcode 0x0F85: JNE, JNZ (jump if ZF = 0)
@@ -1775,7 +1775,7 @@ define dumpjump
                 # ZF = 1
                 color $RED
                 printf "  Jump is NOT taken (z!=0)"
-            end 
+            end
         end
         ## opcode 0x71: JNO (OF = 0)
         ## opcode 0x0F81: JNO (OF = 0)
@@ -1788,7 +1788,7 @@ define dumpjump
                 # OF != 0
                 color $RED
                 printf "  Jump is NOT taken (o!=0)"
-            end 
+            end
         end
         ## opcode 0x7B: JNP, JPO (jump if PF = 0)
         ## opcode 0x0F8B: JPO (jump if PF = 0)
@@ -1801,7 +1801,7 @@ define dumpjump
                 # PF != 0
                 color $RED
                 printf "  Jump is taken (p!=0)"
-            end 
+            end
         end
         ## opcode 0x79: JNS (jump if SF = 0)
         ## opcode 0x0F89: JNS (jump if SF = 0)
@@ -1814,7 +1814,7 @@ define dumpjump
                 # SF != 0
                 color $RED
                 printf "  Jump is NOT taken (s!=0)"
-            end 
+            end
         end
         ## opcode 0x70: JO (jump if OF=1)
         ## opcode 0x0F80: JO (jump if OF=1)
@@ -1827,7 +1827,7 @@ define dumpjump
                 # OF != 1
                 color $RED
                 printf "  Jump is NOT taken (o!=1)"
-            end 
+            end
         end
         ## opcode 0x7A: JP, JPE (jump if PF=1)
         ## opcode 0x0F8A: JP, JPE (jump if PF=1)
@@ -1840,7 +1840,7 @@ define dumpjump
                 # PF = 0
                 color $RED
                 printf "  Jump is NOT taken (p!=1)"
-            end 
+            end
         end
         ## opcode 0x78: JS (jump if SF=1)
         ## opcode 0x0F88: JS (jump if SF=1)
@@ -1853,7 +1853,7 @@ define dumpjump
                 # SF != 1
                 color $RED
                 printf "  Jump is NOT taken (s!=1)"
-            end 
+            end
         end
     end
 end
@@ -2014,7 +2014,7 @@ end
 # initialize variable
 set $displayobjectivec = 0
 
-define context 
+define context
     color $COLOR_SEPARATOR
     if $SHOWCPUREGISTERS == 1
         printf "----------------------------------------"
@@ -2096,8 +2096,8 @@ define context
                 color_reset
                 color $BLACK
                 x/s $objectivec
-            end   
-            set $displayobjectivec = 0     
+            end
+            set $displayobjectivec = 0
         end
         if $displayobjectivec == 1
             color $COLOR_SEPARATOR
@@ -2110,8 +2110,8 @@ define context
             printf "[ObjectiveC]\n"
             color_reset
             color $BLACK
-            x/s $objectivec 
-        end   
+            x/s $objectivec
+        end
     end
     color_reset
 # and this is the end of this little crap
@@ -2131,7 +2131,7 @@ define context
         color_reset
         set $context_i = $CONTEXTSIZE_CODE
         if ($context_i > 0)
-            if ($SETCOLOR1STLINE == 1)	
+            if ($SETCOLOR1STLINE == 1)
                 color $GREEN
                 if ($ARM == 1)
                     #       | $cpsr.t (Thumb flag)
@@ -2294,8 +2294,8 @@ define stepoframework
         # bl and bx opcodes
         # bx Rn  => ARM bits 27-20: 0 0 0 1 0 0 1 0 , bits 7-4: 0 0 0 1 ; Thumb bits: 15-7: 0 1 0 0 0 1 1 1 0
         # blx Rn => ARM bits 27-20: 0 0 0 1 0 0 1 0 , bits 7-4: 0 0 1 1 ; Thumb bits: 15-7: 0 1 0 0 0 1 1 1 1
-        # bl # => ARM bits 27-24: 1 0 1 1 ; Thumb bits: 15-11: 1 1 1 1 0 
-        # blx # => ARM bits 31-25: 1 1 1 1 1 0 1 ; Thumb bits: 15-11: 1 1 1 1 0 
+        # bl # => ARM bits 27-24: 1 0 1 1 ; Thumb bits: 15-11: 1 1 1 1 0
+        # blx # => ARM bits 31-25: 1 1 1 1 1 0 1 ; Thumb bits: 15-11: 1 1 1 1 0
         set $_nextaddress = 0
 
         # ARM Mode
@@ -2328,7 +2328,7 @@ define stepoframework
             #	set $_previousbyte = *(unsigned char *)($pc+2)
             #	set $_bits2320 = $_previousbyte >> 4
             #	printf "bits2724: %x bits2320: %x\n", $_bits2724, $_bits2320
-	
+
             if ($_bit27 == 0 && $_bit26 == 0 && $_bit25 == 0 && $_bit24 == 1 && $_bit23 == 0 && $_bit22 == 0 && $_bit21 == 1 && $_bit20 == 0 && $_bit7 == 0 && $_bit6 == 0 && $_bit5 == 0 && $_bit4 == 1)
                 printf "Found a bx Rn\n"
                 set $_nextaddress = $pc+0x4
@@ -2360,7 +2360,7 @@ define stepoframework
                 end
             end
         end
-        # if we have found a call to bypass we set a temporary breakpoint on next instruction and continue 
+        # if we have found a call to bypass we set a temporary breakpoint on next instruction and continue
         if ($_nextaddress != 0)
             tbreak *$_nextaddress
             continue
@@ -2394,10 +2394,10 @@ define stepoframework
                 end
                 # call *0x??(%ebp) (0xFF55??) || call *0x??(%esi) (0xFF56??) || call *0x??(%edi) (0xFF5F??) || call *0x??(%ebx)
                 # call *0x??(%edx) (0xFF52??) || call *0x??(%ecx) (0xFF51??) || call *0x??(%edi) (0xFF57??) || call *0x??(%eax) (0xFF50??)
-                if ($_byte2 == 0x55 || $_byte2 == 0x56 || $_byte2 == 0x5F || $_byte2 == 0x53 || $_byte2 == 0x52 || $_byte2 == 0x51 || $_byte2 == 0x57 || $_byte2 == 0x50) 
+                if ($_byte2 == 0x55 || $_byte2 == 0x56 || $_byte2 == 0x5F || $_byte2 == 0x53 || $_byte2 == 0x52 || $_byte2 == 0x51 || $_byte2 == 0x57 || $_byte2 == 0x50)
                     set $_nextaddress = $pc + 0x3
                 end
-                # call *0x????????(%ebx) (0xFF93????????) || 
+                # call *0x????????(%ebx) (0xFF93????????) ||
                 if ($_byte2 == 0x93 || $_byte2 == 0x94 || $_byte2 == 0x90 || $_byte2 == 0x92 || $_byte2 == 0x95 || $_byte2 == 0x15)
                     set $_nextaddress = $pc + 6
                 end
@@ -2415,7 +2415,7 @@ define stepoframework
                end
             end
         end
-        # if we have found a call to bypass we set a temporary breakpoint on next instruction and continue 
+        # if we have found a call to bypass we set a temporary breakpoint on next instruction and continue
         if ($_nextaddress != 0)
             if ($arg0 == 1)
                 thbreak *$_nextaddress
@@ -2691,7 +2691,7 @@ define nop
                     set $addr = $addr + 4
                 end
             end
-        end 
+        end
     else
         if ($argc == 1)
             set *(unsigned char *)$arg0 = 0x90
@@ -2881,11 +2881,11 @@ define get_insn_type
                 set $INSN_TYPE = 2
             end
         end
-        if ($_byte1 == 0xFF)        
+        if ($_byte1 == 0xFF)
             # opcode extension
             set $_byte2 = *(unsigned char *)($arg0 + 1)
             set $_opext = ($_byte2 & 0x38)
-            if ($_opext == 0x10 || $_opext == 0x18) 
+            if ($_opext == 0x10 || $_opext == 0x18)
                 # "call"
                 set $INSN_TYPE = 3
             end
@@ -2959,7 +2959,7 @@ define trace_calls
     set $SHOW_NEST_INSN = 0
     set $_nest = 1
     set listsize 0
-  
+
     set logging overwrite on
     set logging file ~/gdb_trace_calls.txt
     set logging enabled on
@@ -3001,7 +3001,7 @@ define trace_calls
 
     set $SHOW_CONTEXT = $_saved_ctx
     set $SHOW_NEST_INSN = 0
- 
+
     printf "Done, check ~/gdb_trace_calls.txt\n"
 end
 document trace_calls
@@ -3012,7 +3012,7 @@ end
 
 
 define trace_run
- 
+
     printf "Tracing...please wait...\n"
 
     set $_saved_ctx = $SHOW_CONTEXT
@@ -3204,7 +3204,7 @@ define assemble
     printf " Do not forget to use NASM assembler syntax!\n"
     color_reset
     printf "End with a line saying just \"end\".\n"
-    
+
     if ($argc)
         if ($64BITS == 1)
             # argument specified, assemble instructions into memory at address specified.
@@ -3261,7 +3261,7 @@ define assemble32
     printf " Do not forget to use NASM assembler syntax!\n"
     color_reset
     printf "End with a line saying just \"end\".\n"
-    
+
     if ($argc)
         # argument specified, assemble instructions into memory at address specified.
         shell ASMOPCODE="$(while read -ep '>' r && test "$r" != end ; do echo -E "$r"; done)" ; GDBASMFILENAME=$RANDOM; \
@@ -3302,7 +3302,7 @@ define assemble64
     printf " Do not forget to use NASM assembler syntax!\n"
     color_reset
     printf "End with a line saying just \"end\".\n"
-    
+
     if ($argc)
         # argument specified, assemble instructions into memory at address specified.
         shell ASMOPCODE="$(while read -ep '>' r && test "$r" != end ; do echo -E "$r"; done)" ; GDBASMFILENAME=$RANDOM; \
@@ -3520,7 +3520,7 @@ end
 define tip_syntax
     printf "\n"
     printf "\t    INTEL SYNTAX                        AT&T SYNTAX\n"
-    printf "\tmnemonic dest, src, imm            mnemonic src, dest, imm\n" 
+    printf "\tmnemonic dest, src, imm            mnemonic src, dest, imm\n"
     printf "\t[base+index*scale+disp]            disp(base, index, scale)\n"
     printf "\tregister:      eax                 register:      %%eax\n"
     printf "\timmediate:     0xFF                immediate:     $0xFF\n"

--- a/gdbinit
+++ b/gdbinit
@@ -127,38 +127,39 @@ set $COLOR_CPUFLAGS = $RED
 
 # this is ugly but there's no else if available :-(
 define color
- if $USECOLOR == 1
-    # BLACK
-    if $arg0 == 0
-        echo \033[30m
-    else
-        # RED
-        if $arg0 == 1
-            echo \033[31m
+    if $USECOLOR == 1
+        # BLACK
+        if $arg0 == 0
+            echo \033[30m
         else
-            # GREEN
-            if $arg0 == 2
-                echo \033[32m
+            # RED
+            if $arg0 == 1
+                echo \033[31m
             else
-                # YELLOW
-                if $arg0 == 3
-                    echo \033[33m
+                # GREEN
+                if $arg0 == 2
+                    echo \033[32m
                 else
-                    # BLUE
-                    if $arg0 == 4
-                        echo \033[34m
+                    # YELLOW
+                    if $arg0 == 3
+                        echo \033[33m
                     else
-                        # MAGENTA
-                        if $arg0 == 5
-                            echo \033[35m
+                        # BLUE
+                        if $arg0 == 4
+                            echo \033[34m
                         else
-                            # CYAN
-                            if $arg0 == 6
-                                echo \033[36m
+                            # MAGENTA
+                            if $arg0 == 5
+                                echo \033[35m
                             else
-                                # WHITE
-                                if $arg0 == 7
-                                    echo \033[37m
+                                # CYAN
+                                if $arg0 == 6
+                                    echo \033[36m
+                                else
+                                    # WHITE
+                                    if $arg0 == 7
+                                        echo \033[37m
+                                    end
                                 end
                             end
                         end
@@ -167,7 +168,6 @@ define color
             end
         end
     end
- end
 end
 
 define color_reset
@@ -660,7 +660,7 @@ define eflags
         printf "  I <%d>  F <%d>  T <%d> \n",\
                (($cpsr >> 7) & 1), (($cpsr >> 6) & 1), \
                (($cpsr >> 5) & 1)
-     else
+    else
         printf "     OF <%d>  DF <%d>  IF <%d>  TF <%d>",\
                (((unsigned int)$eflags >> 0xB) & 1), (((unsigned int)$eflags >> 0xA) & 1), \
                (((unsigned int)$eflags >> 9) & 1), (((unsigned int)$eflags >> 8) & 1)
@@ -673,7 +673,7 @@ define eflags
         printf "  VM <%d>  RF <%d>  NT <%d>  IOPL <%d>\n",\
                (((unsigned int)$eflags >> 0x11) & 1), (((unsigned int)$eflags >> 0x10) & 1),\
                (((unsigned int)$eflags >> 0xE) & 1), (((unsigned int)$eflags >> 0xC) & 3)
-     end
+    end
 end
 document eflags
 Syntax: eflags
@@ -1276,7 +1276,7 @@ define smallregisters
         set $si = $esi & 0xffff
         # from edi
         set $di = $edi & 0xffff
-     end
+    end
 end
 document smallregisters
 Syntax: smallregisters
@@ -2408,11 +2408,11 @@ define stepoframework
             end
             # FIXME: still missing a few?
             if ($_byte1 == 0x41 || $_byte1 == 0x40)
-               if ($_byte2 == 0xFF)
+                if ($_byte2 == 0xFF)
                     if ($_byte3 == 0xD0 || $_byte3 == 0xD1 || $_byte3 == 0xD2 || $_byte3 == 0xD3 || $_byte3 == 0xD4 || $_byte3 == 0xD5 ||  $_byte3 == 0xD6 || $_byte3 == 0xD7)
                         set $_nextaddress = $pc + 0x3
                     end
-               end
+                end
             end
         end
         # if we have found a call to bypass we set a temporary breakpoint on next instruction and continue
@@ -2424,9 +2424,9 @@ define stepoframework
             end
             continue
             # else we just single step
-         else
+        else
             nexti
-         end
+        end
     end
 end
 document stepoframework
@@ -2509,13 +2509,13 @@ define cfc
         else
             set $cpsr->c = $tempflag|0x1
         end
-     else
+    else
         if ((unsigned int)$eflags & 1)
             set $eflags = (unsigned int)$eflags&~0x1
         else
             set $eflags = (unsigned int)$eflags|0x1
         end
-     end
+    end
 end
 document cfc
 Syntax: cfc
@@ -2558,13 +2558,13 @@ define cfz
         else
             set $cpsr->z = $tempflag|0x1
         end
-     else
+    else
         if (((unsigned int)$eflags >> 6) & 1)
             set $eflags = (unsigned int)$eflags&~0x40
         else
             set $eflags = (unsigned int)$eflags|0x40
         end
-     end
+    end
 end
 document cfz
 Syntax: cfz

--- a/gdbinit
+++ b/gdbinit
@@ -26,7 +26,7 @@
 #         An updated version of the patch and binary is available at https://reverse.put.as/2011/02/21/update-to-gdb-patches-fix-a-new-bug/
 #
 # iOS NOTES: iOS gdb from Cydia (and Apple's) suffer from the same OS X bug.
-#			 If you are using this on Mac OS X or iOS, you must either attach gdb to a process
+#            If you are using this on Mac OS X or iOS, you must either attach gdb to a process
 #            or launch gdb without any options and then load the binary file you want to analyse with "exec-file" option
 #            If you load the binary from the command line, like $gdb binary-name, this will not work as it should
 #            For more information, read it here https://reverse.put.as/2008/11/28/apples-gdb-bug/
@@ -822,7 +822,7 @@ define regarm
         color $COLOR_REGVAL
     end
     printf " 0x%08X  ", $sp
-	# LR
+    # LR
     color $COLOR_REGNAME
     printf "LR:"
     if ($lr != $oldlr && $SHOWREGCHANGES == 1)
@@ -904,7 +904,7 @@ define regx64
     printf " 0x%016lX  ", $rdi
     # RSI
     color $COLOR_REGNAME
-   	printf "RSI:"
+    printf "RSI:"
     if ($rsi != $oldrsi && $SHOWREGCHANGES == 1)
         color $COLOR_REGVAL_MODIFIED
     else
@@ -913,7 +913,7 @@ define regx64
     printf " 0x%016lX  ", $rsi
     # RDX
     color $COLOR_REGNAME
-   	printf "RDX:"
+    printf "RDX:"
     if ($rdx != $oldrdx && $SHOWREGCHANGES == 1)
         color $COLOR_REGVAL_MODIFIED
     else
@@ -922,7 +922,7 @@ define regx64
     printf " 0x%016lX  ", $rdx
     # RCX
     color $COLOR_REGNAME
-   	printf "RCX:"
+    printf "RCX:"
     if ($rcx != $oldrcx && $SHOWREGCHANGES == 1)
         color $COLOR_REGVAL_MODIFIED
     else
@@ -936,7 +936,7 @@ define regx64
     printf " 0x%016lX\n  ", $rip
     # R8
     color $COLOR_REGNAME
-   	printf "R8 :"
+    printf "R8 :"
     if ($r8 != $oldr8 && $SHOWREGCHANGES == 1)
         color $COLOR_REGVAL_MODIFIED
     else
@@ -945,7 +945,7 @@ define regx64
     printf " 0x%016lX  ", $r8
     # R9
     color $COLOR_REGNAME
-   	printf "R9 :"
+    printf "R9 :"
     if ($r9 != $oldr9 && $SHOWREGCHANGES == 1)
         color $COLOR_REGVAL_MODIFIED
     else
@@ -954,7 +954,7 @@ define regx64
     printf " 0x%016lX  ", $r9
     # R10
     color $COLOR_REGNAME
-   	printf "R10:"
+    printf "R10:"
     if ($r10 != $oldr10 && $SHOWREGCHANGES == 1)
         color $COLOR_REGVAL_MODIFIED
     else
@@ -962,7 +962,7 @@ define regx64
     end
     printf " 0x%016lX  ", $r10
     # R11
-   	color $COLOR_REGNAME
+    color $COLOR_REGNAME
     printf "R11:"
     if ($r11 != $oldr11 && $SHOWREGCHANGES == 1)
         color $COLOR_REGVAL_MODIFIED
@@ -981,7 +981,7 @@ define regx64
     printf " 0x%016lX\n  ", $r12
     # R13
     color $COLOR_REGNAME
-   	printf "R13:"
+    printf "R13:"
     if ($r13 != $oldr13 && $SHOWREGCHANGES == 1)
         color $COLOR_REGVAL_MODIFIED
     else
@@ -2642,7 +2642,7 @@ end
 # Overflow (V), bit 28
 define cfv
     if $ARM == 1
-    	set $tempflag = $cpsr->v
+        set $tempflag = $cpsr->v
         if ($tempflag & 1)
             set $cpsr->v = $tempflag&~0x1
         else
@@ -2757,7 +2757,7 @@ end
 
 define rint3
     if $ARM == 1
-      	set *(unsigned int *)$ORIGINAL_INT3ADDRESS = $ORIGINAL_INT3
+        set *(unsigned int *)$ORIGINAL_INT3ADDRESS = $ORIGINAL_INT3
         set $pc = $ORIGINAL_INT3ADDRESS
     else
         set *(unsigned char *)$ORIGINAL_INT3ADDRESS = $ORIGINAL_INT3
@@ -3227,7 +3227,7 @@ define assemble
             shell ASMOPCODE="$(while read -ep '>' r && test "$r" != end ; do echo -E "$r"; done)" ; GDBASMFILENAME=$RANDOM; \
             echo -e "BITS 64\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; /usr/local/bin/nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | /usr/local/bin/ndisasm -i -b64 /dev/stdin ; \
             /bin/rm -f /tmp/$GDBASMFILENAME
-    	else
+        else
             # no argument, assemble instructions to stdout
             shell ASMOPCODE="$(while read -ep '>' r && test "$r" != end ; do echo -E "$r"; done)" ; GDBASMFILENAME=$RANDOM; \
             echo -e "BITS 32\n$ASMOPCODE" >/tmp/$GDBASMFILENAME ; /usr/bin/nasm -f bin -o /dev/stdout /tmp/$GDBASMFILENAME | /usr/bin/ndisasm -i -b32 /dev/stdin ; \


### PR DESCRIPTION
Replaces stray tabs with spaces, deletes trailing whitespace, and fixes indentation alignment; no functional changes were made. This can be verified with `git diff -w` which will print nothing.